### PR TITLE
Add RGB matrix stream processor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ rtic-sync = "1.0.2"
 usb-device = "0.2.9"
 usbd-human-interface-device = { version = "0.4.3", features = ["defmt"] }
 frunk = { version = "0.4.2", default-features = false }
+smart-leds = "0.3.0"
+ws2812-pio = "0.7.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,8 @@ use defmt::Format;
 
 use crate::{
     key::{
-        Action::{Key as K, LayerModifier as LM, Pass as ___},
-        Key, LayerIndex,
+        Action::{Control as C, Key as K, LayerModifier as LM, Pass as ___},
+        Control, Key, LayerIndex,
     },
     stream::Mapping,
 };
@@ -11,6 +11,8 @@ use crate::{
 pub const ROW_COUNT: usize = 5;
 pub const COL_COUNT: usize = 15;
 pub const LAYER_COUNT: usize = 3;
+
+pub const LED_COUNT: usize = 67;
 
 pub const KEY_MAP: Mapping<{ ROW_COUNT }, { COL_COUNT }, { LAYER_COUNT }, Layer> = Mapping([
     [
@@ -29,7 +31,7 @@ pub const KEY_MAP: Mapping<{ ROW_COUNT }, { COL_COUNT }, { LAYER_COUNT }, Layer>
             K(Key::Minus),
             K(Key::Equal),
             K(Key::DeleteBackspace),
-            LM(Layer::Function1), // K(Key::PageUp),
+            K(Key::DeleteForward),
         ],
         [
             K(Key::Tab),
@@ -119,10 +121,38 @@ pub const KEY_MAP: Mapping<{ ROW_COUNT }, { COL_COUNT }, { LAYER_COUNT }, Layer>
             ___,
         ],
         [
-            ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___,
+            ___,
+            C(Control::RGBAnimationNext),
+            C(Control::RGBSpeedUp),
+            C(Control::RGBBrightnessUp),
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
         ],
         [
-            ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___,
+            ___,
+            C(Control::RGBAnimationPrevious),
+            C(Control::RGBSpeedDown),
+            C(Control::RGBBrightnessDown),
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
+            ___,
         ],
         [
             ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___,

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,6 +7,7 @@ pub enum Action<L: LayerIndex> {
     Pass,
     None,
     Key(Key),
+    Control(Control),
     LayerModifier(L),
 }
 
@@ -206,4 +207,16 @@ impl Into<Keyboard> for Key {
     }
 }
 
-pub trait LayerIndex: Copy + Into<usize> {}
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Format, PartialEq)]
+pub enum Control {
+    RGBAnimationNext,
+    RGBAnimationPrevious,
+    RGBSpeedUp,
+    RGBSpeedDown,
+    RGBBrightnessUp,
+    RGBBrightnessDown,
+    RGBDirectionToggle,
+}
+
+pub trait LayerIndex: Copy + Into<usize> + Format {}

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -101,7 +101,7 @@ impl<const LED_COUNT: usize> RGBProcessor<{ LED_COUNT }> {
 }
 
 impl<const LED_COUNT: usize, L: LayerIndex> EventsProcessor<L> for RGBProcessor<{ LED_COUNT }> {
-    async fn process(&mut self, events: &mut Vec<Event<L>>) -> StreamResult {
+    fn process(&mut self, events: &mut Vec<Event<L>>) -> StreamResult {
         events.into_iter().for_each(|e| {
             if e.edge == Edge::Rising {
                 match e.action {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,0 +1,300 @@
+extern crate alloc;
+use alloc::{boxed::Box, vec::Vec};
+
+use core::ops::Mul;
+use rtic_monotonics::{rp2040::*, Monotonic};
+use rtic_sync::channel::{Receiver, Sender};
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+
+use crate::{
+    key::{Action, Control, LayerIndex},
+    matrix::Edge,
+    stream::{Event, EventsProcessor, Result as StreamResult},
+};
+
+// More than 64 pulls too much power, it fries the board
+const LED_MAX_BRIGHTNESS: u8 = 28;
+
+const FRAME_TIME_MIN_MICROS: u64 = 1_000;
+const FRAME_TIME_DEFAULT_MICROS: u64 = 20_000;
+const FRAME_TIME_MAX_MICROS: u64 = 1_000_000;
+
+type Frame<const LED_COUNT: usize> = [RGB8; LED_COUNT];
+
+#[derive(Clone, Copy)]
+pub struct RGBMatrix<const LED_COUNT: usize, W: SmartLedsWrite>
+where
+    W::Color: From<RGB8>,
+{
+    writer: W,
+}
+
+impl<const LED_COUNT: usize, W: SmartLedsWrite> RGBMatrix<LED_COUNT, W>
+where
+    W::Color: From<RGB8>,
+{
+    pub fn new(writer: W) -> Self {
+        return RGBMatrix { writer };
+    }
+
+    pub async fn render(
+        &mut self,
+        mut frame_receiver: Receiver<'static, Box<dyn Iterator<Item = RGB8>>, 1>,
+    ) {
+        while let Ok(frame) = frame_receiver.recv().await {
+            self.writer
+                .write(brightness(frame, LED_MAX_BRIGHTNESS))
+                .ok();
+        }
+    }
+}
+
+struct AnimationState<const LED_COUNT: usize> {
+    t: u64,
+    n: u8,
+    frame: Frame<{ LED_COUNT }>,
+}
+
+impl<const LED_COUNT: usize> AnimationState<LED_COUNT> {
+    fn step(&mut self) {
+        self.t = self.t.wrapping_add(1);
+        self.n = self.n.wrapping_add(1);
+    }
+}
+
+impl<const LED_COUNT: usize> Default for AnimationState<LED_COUNT> {
+    fn default() -> Self {
+        Self {
+            t: 0,
+            n: 0,
+            frame: [Default::default(); LED_COUNT],
+        }
+    }
+}
+
+pub struct RGBProcessor<const LED_COUNT: usize> {
+    animations:
+        [Box<dyn AnimationIterator<{ LED_COUNT }, Item = Box<dyn Iterator<Item = RGB8>>>>; 4],
+    animation_idx: usize,
+    frame_sender: Sender<'static, Box<dyn Iterator<Item = RGB8>>, 1>,
+    last_render: <rtic_monotonics::rp2040::Timer as Monotonic>::Instant,
+    frame_time_micros: u64,
+    brightness: u8,
+}
+
+impl<const LED_COUNT: usize> RGBProcessor<{ LED_COUNT }> {
+    pub fn new(frame_sender: Sender<'static, Box<dyn Iterator<Item = RGB8>>, 1>) -> Self {
+        return RGBProcessor {
+            animations: [
+                Box::new(WheelAnimation::new(Default::default())),
+                Box::new(BreatheAnimation::new(Default::default())),
+                Box::new(ScanAnimation::new(Default::default())),
+                Box::new(NoneAnimation::new()),
+            ],
+            animation_idx: 0,
+            frame_sender,
+            last_render: Timer::now(),
+            frame_time_micros: FRAME_TIME_DEFAULT_MICROS,
+            brightness: 255,
+        };
+    }
+}
+
+impl<const LED_COUNT: usize, L: LayerIndex> EventsProcessor<L> for RGBProcessor<{ LED_COUNT }> {
+    async fn process(&mut self, events: &mut Vec<Event<L>>) -> StreamResult {
+        events.into_iter().for_each(|e| {
+            if e.edge == Edge::Rising {
+                match e.action {
+                    Action::Control(k) => match k {
+                        Control::RGBAnimationPrevious => {
+                            self.animation_idx = if self.animation_idx == 0 {
+                                self.animations.len() - 1
+                            } else {
+                                self.animation_idx - 1
+                            };
+                        }
+                        Control::RGBAnimationNext => {
+                            self.animation_idx = if self.animation_idx == self.animations.len() - 1
+                            {
+                                0
+                            } else {
+                                self.animation_idx + 1
+                            };
+                        }
+
+                        Control::RGBSpeedDown => {
+                            if self.frame_time_micros < FRAME_TIME_MAX_MICROS {
+                                self.frame_time_micros = self.frame_time_micros.mul(2)
+                            }
+                        }
+                        Control::RGBSpeedUp => {
+                            if self.frame_time_micros > FRAME_TIME_MIN_MICROS {
+                                self.frame_time_micros = self.frame_time_micros.div_ceil(2)
+                            }
+                        }
+
+                        Control::RGBBrightnessDown => {
+                            self.brightness = self.brightness.saturating_sub(16)
+                        }
+                        Control::RGBBrightnessUp => {
+                            self.brightness = self.brightness.saturating_add(16)
+                        }
+
+                        _ => {}
+                    },
+                    _ => {}
+                }
+            }
+        });
+
+        match Timer::now().checked_duration_since(self.last_render) {
+            Some(d) if d > self.frame_time_micros.micros::<1, 1_000_000>() => {
+                self.frame_sender
+                    .try_send(Box::new(brightness(
+                        self.animations[self.animation_idx].next().unwrap(),
+                        self.brightness,
+                    )))
+                    .ok();
+                self.last_render = Timer::now();
+            }
+            _ => {}
+        };
+
+        Ok(())
+    }
+}
+
+trait DirectionControl {
+    fn set_direction(&mut self, left: bool);
+}
+
+trait AnimationIterator<const LED_COUNT: usize> {
+    type Item = Box<dyn Iterator<Item = RGB8>>;
+
+    fn next(&mut self) -> Option<Self::Item>;
+}
+
+struct NoneAnimation {}
+
+impl NoneAnimation {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<const LED_COUNT: usize> AnimationIterator<LED_COUNT> for NoneAnimation {
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(Box::new([(0, 0, 0).into(); LED_COUNT].into_iter()))
+    }
+}
+
+struct ScanAnimation<const LED_COUNT: usize> {
+    animation_state: AnimationState<{ LED_COUNT }>,
+    direction_left: bool,
+}
+
+impl<const LED_COUNT: usize> ScanAnimation<LED_COUNT> {
+    fn new(animation_state: AnimationState<LED_COUNT>) -> Self
+    where
+        Self: Sized,
+    {
+        return Self {
+            animation_state,
+            direction_left: false,
+        };
+    }
+}
+
+impl<const LED_COUNT: usize> AnimationIterator<LED_COUNT> for ScanAnimation<LED_COUNT> {
+    fn next(&mut self) -> Option<Box<dyn Iterator<Item = RGB8>>> {
+        self.animation_state.step();
+        for (i, d) in self.animation_state.frame.iter_mut().enumerate() {
+            *d = if self.animation_state.t as usize % LED_COUNT == i {
+                (255, 255, 255).into()
+            } else {
+                (0, 0, 0).into()
+            };
+        }
+        Some(Box::new(self.animation_state.frame.into_iter()))
+    }
+}
+
+impl<const LED_COUNT: usize> DirectionControl for ScanAnimation<LED_COUNT> {
+    fn set_direction(&mut self, left: bool) {
+        self.direction_left = left;
+    }
+}
+
+struct BreatheAnimation<const LED_COUNT: usize> {
+    animation_state: AnimationState<{ LED_COUNT }>,
+}
+
+impl<const LED_COUNT: usize> BreatheAnimation<LED_COUNT> {
+    fn new(animation_state: AnimationState<LED_COUNT>) -> Self
+    where
+        Self: Sized,
+    {
+        return Self { animation_state };
+    }
+
+    fn breathe(mut t: u8) -> RGB8 {
+        if t < 128 {
+            t = t * 2;
+        } else {
+            t = (255 - t) * 2;
+        }
+        return (t, t, t).into();
+    }
+}
+
+impl<const LED_COUNT: usize> AnimationIterator<LED_COUNT> for BreatheAnimation<LED_COUNT> {
+    fn next(&mut self) -> Option<Box<dyn Iterator<Item = RGB8>>> {
+        self.animation_state.step();
+        for (i, d) in self.animation_state.frame.iter_mut().enumerate() {
+            *d = Self::breathe(
+                self.animation_state
+                    .n
+                    .wrapping_add((i * 128 / LED_COUNT) as u8),
+            );
+        }
+        Some(Box::new(self.animation_state.frame.into_iter()))
+    }
+}
+
+struct WheelAnimation<const LED_COUNT: usize> {
+    animation_state: AnimationState<{ LED_COUNT }>,
+}
+
+impl<const LED_COUNT: usize> WheelAnimation<LED_COUNT> {
+    fn new(animation_state: AnimationState<LED_COUNT>) -> Self
+    where
+        Self: Sized,
+    {
+        return Self { animation_state };
+    }
+
+    fn wheel(mut rot: u8) -> RGB8 {
+        if rot < 85 {
+            return (0, 255 - (rot * 3), rot * 3).into();
+        } else if rot < 170 {
+            rot -= 85;
+            return (rot * 3, 0, 255 - (rot * 3)).into();
+        } else {
+            rot -= 170;
+            return (255 - (rot * 3), rot * 3, 0).into();
+        }
+    }
+}
+impl<const LED_COUNT: usize> AnimationIterator<LED_COUNT> for WheelAnimation<LED_COUNT> {
+    fn next(&mut self) -> Option<Box<dyn Iterator<Item = RGB8>>> {
+        self.animation_state.step();
+        for (i, d) in self.animation_state.frame.iter_mut().enumerate() {
+            *d = Self::wheel(
+                self.animation_state
+                    .n
+                    .wrapping_add((i * 255 / LED_COUNT) as u8),
+            );
+        }
+        Some(Box::new(self.animation_state.frame.into_iter()))
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -131,7 +131,7 @@ impl<const ROW_COUNT: usize, const COL_COUNT: usize, const LAYER_COUNT: usize, L
 }
 
 pub trait EventsProcessor<L: LayerIndex> {
-    async fn process(&mut self, events: &mut Vec<Event<L>>) -> Result;
+    fn process(&mut self, events: &mut Vec<Event<L>>) -> Result;
 }
 
 pub struct KeyReplacer {
@@ -147,7 +147,7 @@ impl KeyReplacer {
 }
 
 impl<L: LayerIndex> EventsProcessor<L> for KeyReplacer {
-    async fn process(&mut self, events: &mut Vec<Event<L>>) -> Result {
+    fn process(&mut self, events: &mut Vec<Event<L>>) -> Result {
         events.iter_mut().for_each(|e| match &mut e.action {
             Action::Key(k) => {
                 if *k == self.from {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -105,15 +105,12 @@ impl<const ROW_COUNT: usize, const COL_COUNT: usize, const LAYER_COUNT: usize, L
                 for (j, (edge, pressed)) in row.iter().enumerate() {
                     let action = self.mapping[layer_idx][i][j];
                     if *pressed {
-                        match action {
-                            Action::LayerModifier(l) => {
-                                if layer_idx < l.into() {
-                                    new_layer = true;
-                                    layer_idx = l.into();
-                                    break; // repeat resolving on the next layer
-                                }
+                        if let Action::LayerModifier(l) = action {
+                            if layer_idx < l.into() {
+                                new_layer = true;
+                                layer_idx = l.into();
+                                break; // repeat resolving on the next layer
                             }
-                            _ => {}
                         }
                     }
                     if !(*edge == Edge::None && !*pressed) {


### PR DESCRIPTION
Add rudimentary implementation of RGB processor based on events.

Rendering of frames is done directly on the "screen"-space (i.e., physical LED matrix) without any rendering from a representational model.

Simple animations included:
- Breathe
- Wheel
- Scan (debug)
- None

Together with the following controls:
- Animation selection
- Speed
- Brightness