### PR TITLE
Add concurrent flip input processor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,10 @@ mod kb {
         matrix::{BasicVerticalSwitchMatrix, Scanner},
         processor::{
             events::rgb::{FrameIterator, RGBMatrix, RGBProcessor},
-            input::debounce::KeyMatrixRisingFallingDebounceProcessor,
+            input::{
+                debounce::KeyMatrixRisingFallingDebounceProcessor,
+                flip::{ConcurrentFlipProcessor, Pos},
+            },
             mapper::{Input, Mapper},
             Event, EventsProcessor, InputProcessor,
         },
@@ -308,9 +311,10 @@ mod kb {
         let input_processors: &mut [&mut dyn InputProcessor<
             { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT },
             { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT },
-        >] = &mut [&mut KeyMatrixRisingFallingDebounceProcessor::new(
-            10.millis(),
-        )];
+        >] = &mut [
+            &mut KeyMatrixRisingFallingDebounceProcessor::new(10.millis()),
+            &mut ConcurrentFlipProcessor::new(Pos { row: 2, col: 1 }, Pos { row: 2, col: 3 }),
+        ];
         let mut mapper = Mapper::new(<Keyboard as KeyboardConfiguration>::get_input_map());
         let events_processors: &mut [&mut dyn EventsProcessor<
             <Keyboard as KeyboardConfiguration>::Layer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ mod kb {
 
     use crate::{
         heartbeat::HeartbeatLED,
-        key::{Action, Key},
+        key::{Action, Edge, Key},
         keyboard::{Keyboard, KeyboardConfiguration},
         matrix::{BasicVerticalSwitchMatrix, Scanner},
         processor::{
@@ -84,6 +84,7 @@ mod kb {
     const DEBUG_LOG_INPUT_SCANNER_INTERVAL: u64 = 50;
     const DEBUG_LOG_PROCESSOR_ENABLE_TIMING: bool = false;
     const DEBUG_LOG_PROCESSOR_INTERVAL: u64 = 50;
+    const DEBUG_LOG_EVENTS: bool = true;
     const DEBUG_LOG_SENT_KEYS: bool = false;
 
     #[shared]
@@ -337,6 +338,13 @@ mod kb {
             let mut events =
                 Vec::<Event<<Keyboard as KeyboardConfiguration>::Layer>>::with_capacity(10);
             mapper.map(&input, &mut events);
+
+            if DEBUG_LOG_EVENTS {
+                events
+                    .iter()
+                    .filter(|e| e.edge != Edge::None)
+                    .for_each(|e| debug!("[{}] event: action: {} edge: {}", n, e.action, e.edge));
+            }
 
             if events_processors
                 .iter_mut()

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -12,7 +12,7 @@ pub struct Result<const ROW_COUNT: usize, const COL_COUNT: usize> {
     pub matrix: [[Bit; COL_COUNT]; ROW_COUNT],
 }
 
-#[derive(Clone, Copy, Debug, Format)]
+#[derive(Clone, Copy, Debug, Default, Format)]
 pub struct Bit {
     pub edge: Edge,
     pub pressed: bool,

--- a/src/processor/input/flip.rs
+++ b/src/processor/input/flip.rs
@@ -1,0 +1,73 @@
+use defmt::Format;
+
+use crate::{
+    key::Edge,
+    matrix::Bit,
+    processor::{mapper::Input, InputProcessor, Result},
+};
+
+pub struct ConcurrentFlipProcessor {
+    key1_pos: Pos,
+    key2_pos: Pos,
+    previous_pressed_state: (bool, bool),
+}
+
+#[derive(Clone, Copy, Debug, Format)]
+pub struct Pos {
+    pub row: usize,
+    pub col: usize,
+}
+
+#[allow(dead_code)]
+impl ConcurrentFlipProcessor {
+    pub fn new(key1_pos: Pos, key2_pos: Pos) -> Self {
+        ConcurrentFlipProcessor {
+            key1_pos,
+            key2_pos,
+            previous_pressed_state: (false, false),
+        }
+    }
+}
+
+impl<const KEY_MATRIX_ROW_COUNT: usize, const KEY_MATRIX_COL_COUNT: usize>
+    InputProcessor<KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT> for ConcurrentFlipProcessor
+{
+    fn process(&mut self, input: &mut Input<KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT>) -> Result {
+        let key1_bit = input.key_matrix_result.matrix[self.key1_pos.row][self.key1_pos.col];
+        let key2_bit = input.key_matrix_result.matrix[self.key2_pos.row][self.key2_pos.col];
+
+        let pressed_state = if key1_bit.edge == Edge::Rising {
+            (true, false)
+        } else if key1_bit.edge == Edge::Falling {
+            if key2_bit.pressed {
+                (false, true)
+            } else {
+                (false, false)
+            }
+        } else if key2_bit.edge == Edge::Rising {
+            (false, true)
+        } else if key2_bit.edge == Edge::Falling {
+            if key1_bit.pressed {
+                (true, false)
+            } else {
+                (false, false)
+            }
+        } else if !key1_bit.pressed && !key2_bit.pressed {
+            (false, false) // reset to idle
+        } else {
+            self.previous_pressed_state // no edge changes, maintain pressed state
+        };
+
+        input.key_matrix_result.matrix[self.key1_pos.row][self.key1_pos.col] = Bit {
+            edge: Edge::from((self.previous_pressed_state.0, pressed_state.0)),
+            pressed: pressed_state.0,
+        };
+        input.key_matrix_result.matrix[self.key2_pos.row][self.key2_pos.col] = Bit {
+            edge: Edge::from((self.previous_pressed_state.1, pressed_state.1)),
+            pressed: pressed_state.1,
+        };
+
+        self.previous_pressed_state = pressed_state;
+        Ok(())
+    }
+}

--- a/src/processor/input/mod.rs
+++ b/src/processor/input/mod.rs
@@ -1,2 +1,3 @@
 pub mod debounce;
+pub mod flip;
 pub mod none;


### PR DESCRIPTION
Add concurrent flip input processor. This processor enables a mutual exclusive input for the two given key positions on the key matrix.

Concurrent flip is similar to Razer's [Snap Tap](https://www.razer.com/technology/snap-tap-mode) or Wooting's [SOCD](https://wooting.io/post/socd-our-implementation-of-snap-tap).

This is implemented by completely decoupling the two given keys on the key matrix scan result from the mapper, maintaining a pair of pressed states on this processor's instance.

Debug logs for events in the processor loop are also added in this PR.