### PR TITLE
Use probe-rs target runner

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# runner = "probe-run --chip RP2040"
-runner = "elf2uf2-rs -d"
+runner = "probe-rs run --chip RP2040"
+# runner = "elf2uf2-rs -d"
 rustflags = [
     "-C",
     "linker=flip-link",


### PR DESCRIPTION
Replace the target runner from the deprecated [knurling-rs/probe-run](https://github.com/knurling-rs/probe-run) to [probe-rs/probe-rs](https://github.com/probe-rs/probe-rs).
