### PR TITLE
Support split keyboards

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,16 @@
+[alias]
+run_probe = [
+    "--config",
+    "target.'cfg(all(target_arch = \"arm\", target_os = \"none\"))'.runner = 'probe-rs run --chip RP2040'",
+    "run",
+]
+run_u2f = [
+    "--config",
+    "target.'cfg(all(target_arch = \"arm\", target_os = \"none\"))'.runner = 'elf2uf2-rs -d'",
+    "run",
+]
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-rs run --chip RP2040"
-# runner = "elf2uf2-rs -d"
 rustflags = [
     "-C",
     "linker=flip-link",

--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,2 +1,6 @@
 export KEYBOARD=default
 export LAYOUT=default
+
+# VID, PID, and Serial are obtained from `probe-rs list`
+export LEFT_PROBE="vid:pid:serial"
+export RIGHT_PROBE="vid:pid:serial"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,12 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -79,6 +96,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "cortex-m"
@@ -248,6 +271,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -364,6 +393,15 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -379,11 +417,25 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -410,19 +462,24 @@ dependencies = [
 name = "kb"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "cortex-m",
  "defmt",
  "defmt-rtt",
  "embedded-alloc",
  "embedded-hal 1.0.0",
+ "embedded-io 0.6.1",
  "enum-map",
  "frunk",
+ "nb 1.1.0",
  "panic-probe",
+ "postcard",
  "rp2040-boot2",
  "rp2040-hal",
  "rtic",
  "rtic-monotonics",
  "rtic-sync",
+ "serde",
  "smart-leds",
  "usb-device",
  "usbd-human-interface-device",
@@ -434,6 +491,16 @@ name = "linked_list_allocator"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "nb"
@@ -563,6 +630,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postcard"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,7 +728,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
+ "embedded-io 0.6.1",
  "frunk",
  "fugit",
  "itertools",
@@ -753,7 +833,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-bus",
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
  "rtic-common",
 ]
@@ -778,8 +858,23 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.23",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -791,10 +886,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
 
 [[package]]
 name = "smart-leds"
@@ -812,6 +933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf6d833fa93f16a1c1874e62c2aebe8567e5bdd436d59bf543ed258b6f7a8e3"
 dependencies = [
  "rgb",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -880,7 +1010,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -892,7 +1022,7 @@ checksum = "9f549646a39027f191f865a222f20b1886e4c16848d67a43191f63c1a9d59c07"
 dependencies = [
  "frunk",
  "fugit",
- "heapless",
+ "heapless 0.8.0",
  "num_enum 0.7.2",
  "option-block",
  "packed_struct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ panic-probe = { version = "0.3.1", features = ["print-defmt"] }
 cortex-m = "0.7.7"
 embedded-alloc = "0.5.1"
 embedded-hal = "1.0.0"
+embedded-io = "0.6.1"
 rp2040-boot2 = "0.3.0"
 rp2040-hal = { version = "0.10.2", features = ["rt", "critical-section-impl"] }
 
@@ -23,7 +24,12 @@ usb-device = "0.3.2"
 usbd-human-interface-device = "0.5.0"
 smart-leds = "0.3.0"
 ws2812-pio = "0.8.0"
+
+serde = { version = "1.0.204", default-features = false, features = ["derive"] }
+postcard = { version = "1.0.8", features = ["alloc"] }
 enum-map = "2.7.3"
+nb = "1.1.0"
+async-trait = "0.1.81"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CARGO:=$(shell which cargo)
+
+.PHONY: build
+build:
+	${CARGO} build
+
+.PHONY: lint
+lint:
+	${CARGO} clippy
+
+.PHONY: run_u2f
+run_u2f:
+	${CARGO} run_u2f
+
+.PHONY: run_probe_left
+run_probe_left:
+	${CARGO} run_probe -- --probe ${LEFT_PROBE}
+
+.PHONY: run_probe_right
+run_probe_right:
+	${CARGO} run_probe -- --probe ${RIGHT_PROBE}

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,108 @@
+use alloc::string::String;
+use defmt::Format;
+use rtic_monotonics::Monotonic;
+
+use crate::kb::{Mono, HEAP};
+
+pub const ENABLE_LOG_INPUT_SCANNER_ENABLE_TIMING: bool = false;
+pub const ENABLE_LOG_PROCESSOR_ENABLE_TIMING: bool = false;
+pub const ENABLE_LOG_EVENTS: bool = true;
+pub const ENABLE_LOG_SENT_KEYS: bool = false;
+
+const ENABLE_LOG_HEAP: bool = true;
+const ENABLE_LOG_DURATION: bool = true;
+const ENABLE_LOG_STRING: bool = true;
+
+const LOG_HEAP_SAMPLING_RATE: u32 = 5000;
+pub const LOG_INPUT_SCANNER_SAMPLING_RATE: u64 = 50;
+pub const LOG_PROCESSOR_SAMPLING_RATE: u64 = 50;
+const LOG_DURATION_SAMPLING_RATE: u32 = 1000;
+const LOG_STRING_SAMPLING_RATE: u32 = 500;
+
+static mut LOG_HEAP_COUNTER: u32 = 0;
+
+pub fn log_heap() {
+    if !ENABLE_LOG_HEAP {
+        return;
+    }
+    let counter = unsafe {
+        LOG_HEAP_COUNTER = LOG_HEAP_COUNTER.wrapping_add(1);
+        LOG_HEAP_COUNTER
+    };
+    if counter % LOG_HEAP_SAMPLING_RATE == 0 {
+        defmt::trace!(
+            "[{}] ========= heap stat: free={}B used={}B",
+            counter,
+            HEAP.free(),
+            HEAP.used()
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Format)]
+#[repr(u8)]
+pub enum LogDurationTag {
+    KeyMatrixScan,
+
+    ClientInputScan,
+
+    ServerListenRetrieve,
+    ServerListenDispatch,
+    ServerListenRespond,
+    ServerListenFull,
+
+    UARTSenderSendSerialize,
+    UARTSenderSendTransform,
+    UARTSenderSendWrite,
+
+    UARTReceiverReadRead,
+    UARTReceiverReadDeserialize,
+    UARTReceiverReadBuffer,
+
+    UARTIRQRecieveBuffer,
+}
+
+static mut LOG_DURATION_COUNTER: [u32; u8::MAX as usize] = [0; u8::MAX as usize];
+
+pub fn log_duration(
+    tag: LogDurationTag,
+    start_time: <Mono as Monotonic>::Instant,
+    end_time: <Mono as Monotonic>::Instant,
+) {
+    if !ENABLE_LOG_DURATION {
+        return;
+    }
+    let counter = unsafe {
+        LOG_DURATION_COUNTER[tag as usize] = LOG_DURATION_COUNTER[tag as usize].wrapping_add(1);
+        LOG_DURATION_COUNTER[tag as usize]
+    };
+    if counter % LOG_DURATION_SAMPLING_RATE == 0 {
+        defmt::trace!(
+            "[{}] ========= {}: {}us",
+            counter,
+            tag,
+            (end_time - start_time).to_micros()
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Format)]
+#[repr(u8)]
+pub enum LogStringTag {
+    PacketLength,
+}
+
+static mut LOG_STRING_COUNTER: u32 = 0;
+
+pub fn log_string(tag: LogStringTag, str: String) {
+    if !ENABLE_LOG_STRING {
+        return;
+    }
+    let counter = unsafe {
+        LOG_STRING_COUNTER = LOG_STRING_COUNTER.wrapping_add(1);
+        LOG_STRING_COUNTER
+    };
+    if counter % LOG_STRING_SAMPLING_RATE == 0 {
+        defmt::trace!("[{}] ========= {}: {}", counter, tag, str.as_str());
+    }
+}

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,24 +1,26 @@
 use alloc::boxed::Box;
 use embedded_hal::pwm::SetDutyCycle;
 use hal::gpio;
+use rtic_monotonics::Monotonic;
 
-use crate::util;
+use crate::{kb::Mono, util};
 
 const MAX_PWM_POWER: u16 = 0x6000;
+const STEP: u16 = 64;
 
 pub struct HeartbeatLED {
-    pin: Box<dyn SetDutyCycle<Error = gpio::Error>>,
+    pin: Box<dyn SetDutyCycle<Error = gpio::Error> + Sync + Send>,
 }
 
 impl HeartbeatLED {
-    pub fn new(pin: Box<dyn SetDutyCycle<Error = gpio::Error>>) -> Self {
+    pub fn new(pin: Box<dyn SetDutyCycle<Error = gpio::Error> + Sync + Send>) -> Self {
         HeartbeatLED { pin }
     }
 
-    pub async fn cycle(&mut self) {
+    pub async fn cycle(&mut self, period: <Mono as Monotonic>::Duration) -> ! {
         loop {
-            util::lerp(&mut self.pin, 0, MAX_PWM_POWER, 200, 10).await;
-            util::lerp(&mut self.pin, MAX_PWM_POWER, 0, 200, 10).await;
+            util::lerp(&mut self.pin, 0, MAX_PWM_POWER, STEP, period).await;
+            util::lerp(&mut self.pin, MAX_PWM_POWER, 0, STEP, period).await;
         }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,5 @@
 use defmt::Format;
+use serde::{Deserialize, Serialize};
 use usbd_human_interface_device::page::Keyboard;
 
 #[allow(dead_code)]
@@ -220,7 +221,7 @@ pub enum Control {
 
 pub trait LayerIndex: Copy + Default + PartialEq + PartialOrd + Format + Into<usize> {}
 
-#[derive(Clone, Copy, Debug, Default, Format, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Format, PartialEq, Serialize)]
 pub enum Edge {
     #[default]
     None,

--- a/src/keyboard/default/layout/default.rs
+++ b/src/keyboard/default/layout/default.rs
@@ -7,7 +7,7 @@ use crate::{
         Action::{Control as C, Key as K, LayerModifier as LM, Pass as ___________},
         Control, Key, LayerIndex,
     },
-    keyboard::KeyboardConfiguration,
+    keyboard::Configurator,
     processor::mapper::InputMap,
     rotary::Direction,
 };
@@ -30,7 +30,7 @@ impl From<Layer> for usize {
 }
 
 #[rustfmt::skip]
-pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as KeyboardConfiguration>::LAYER_COUNT }, { <super::super::Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as KeyboardConfiguration>::Layer> {
+pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
     InputMap::new(
         [
             [

--- a/src/keyboard/kb_dev/layout/default.rs
+++ b/src/keyboard/kb_dev/layout/default.rs
@@ -7,7 +7,7 @@ use crate::{
         Action::{Control as C, Key as K, LayerModifier as LM, Pass as ___________},
         Control, Key, LayerIndex,
     },
-    keyboard::KeyboardConfiguration,
+    keyboard::Configurator,
     processor::mapper::InputMap,
     rotary::Direction,
 };
@@ -31,7 +31,7 @@ impl From<Layer> for usize {
 }
 
 #[rustfmt::skip]
-pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as KeyboardConfiguration>::LAYER_COUNT }, { <super::super::Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as KeyboardConfiguration>::Layer> {
+pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
     InputMap::new(
         [
             [

--- a/src/keyboard/kb_dev/mod.rs
+++ b/src/keyboard/kb_dev/mod.rs
@@ -1,14 +1,18 @@
 pub mod layout;
 
-use alloc::boxed::Box;
+use core::cell::RefCell;
+
+use alloc::{boxed::Box, rc::Rc};
 use hal::{fugit::HertzU32, gpio, pac, pio, pwm};
+use rtic_sync::arbiter::Arbiter;
 use ws2812_pio::Ws2812Direct;
 
 use crate::{
     heartbeat::HeartbeatLED,
-    keyboard::KeyboardConfiguration,
+    keyboard::{Configuration, Configurator},
     matrix::BasicVerticalSwitchMatrix,
     processor::events::rgb::RGBMatrix,
+    remote::transport::uart::{UartReceiver, UartSender},
     rotary::{Mode, RotaryEncoder},
 };
 
@@ -19,7 +23,7 @@ const ENABLE_RGB_MATRIX: bool = true;
 
 pub struct Keyboard {}
 
-impl KeyboardConfiguration for Keyboard {
+impl Configurator for Keyboard {
     const KEY_MATRIX_ROW_COUNT: usize = 5;
     const KEY_MATRIX_COL_COUNT: usize = 15;
 
@@ -30,26 +34,12 @@ impl KeyboardConfiguration for Keyboard {
         mut slices: pwm::Slices,
         mut pio0: pio::PIO<pac::PIO0>,
         sm0: pio::UninitStateMachine<(pac::PIO0, pio::SM0)>,
+        _uart0: pac::UART0,
+        _resets: &mut pac::RESETS,
         clock_freq: HertzU32,
     ) -> (
-        Option<
-            BasicVerticalSwitchMatrix<
-                { Self::KEY_MATRIX_ROW_COUNT },
-                { Self::KEY_MATRIX_COL_COUNT },
-            >,
-        >,
-        Option<RotaryEncoder>,
-        Option<HeartbeatLED>,
-        Option<
-            RGBMatrix<
-                { Self::RGB_MATRIX_LED_COUNT },
-                Ws2812Direct<
-                    pac::PIO0,
-                    pio::SM0,
-                    gpio::Pin<gpio::bank0::Gpio28, gpio::FunctionPio0, gpio::PullDown>,
-                >,
-            >,
-        >,
+        Configuration,
+        Option<(Arbiter<Rc<RefCell<UartSender>>>, UartReceiver)>,
     ) {
         #[rustfmt::skip]
         let key_matrix = if ENABLE_KEY_MATRIX {
@@ -107,17 +97,21 @@ impl KeyboardConfiguration for Keyboard {
         };
 
         let rgb_matrix = if ENABLE_RGB_MATRIX {
-            let ws = ws2812_pio::Ws2812Direct::new(
-                pins.gpio28.into_function(),
-                &mut pio0,
-                sm0,
-                clock_freq,
-            );
+            let ws = Ws2812Direct::new(pins.gpio28.into_function(), &mut pio0, sm0, clock_freq);
             Some(RGBMatrix::<{ Keyboard::RGB_MATRIX_LED_COUNT }, _>::new(ws))
         } else {
             None
         };
 
-        (key_matrix, rotary_encoder, heartbeat_led, rgb_matrix)
+        (
+            Configuration {
+                key_matrix,
+                key_matrix_split: None,
+                rotary_encoder,
+                heartbeat_led,
+                rgb_matrix,
+            },
+            None,
+        )
     }
 }

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -26,7 +26,11 @@ mod kb_dev;
 #[cfg(keyboard = "kb_dev")]
 use kb_dev as selected_keyboard;
 
-pub trait KeyboardConfiguration {
+#[cfg(keyboard = "quadax_rift")]
+mod quadax_rift;
+#[cfg(keyboard = "quadax_rift")]
+use quadax_rift as selected_keyboard;
+
 #[derive(Default)]
 pub struct Configuration {
     pub key_matrix: Option<

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -1,13 +1,20 @@
+use core::cell::RefCell;
+
+use alloc::rc::Rc;
 use hal::{fugit::HertzU32, gpio, pac, pio, pwm};
+use rtic_sync::arbiter::Arbiter;
 use ws2812_pio::Ws2812Direct;
 
 use crate::{
     heartbeat::HeartbeatLED,
     key::LayerIndex,
-    matrix::BasicVerticalSwitchMatrix,
+    matrix::{BasicVerticalSwitchMatrix, SplitSwitchMatrix},
     processor::{events::rgb::RGBMatrix, mapper::InputMap},
+    remote::transport::uart::{UartReceiver, UartSender},
     rotary::RotaryEncoder,
 };
+
+pub use selected_keyboard::Keyboard;
 
 #[cfg(keyboard = "default")]
 mod default;
@@ -20,6 +27,42 @@ mod kb_dev;
 use kb_dev as selected_keyboard;
 
 pub trait KeyboardConfiguration {
+#[derive(Default)]
+pub struct Configuration {
+    pub key_matrix: Option<
+        BasicVerticalSwitchMatrix<
+            { selected_keyboard::Keyboard::KEY_MATRIX_ROW_COUNT },
+            { selected_keyboard::Keyboard::KEY_MATRIX_COL_COUNT },
+        >,
+    >,
+    pub key_matrix_split: Option<
+        SplitSwitchMatrix<
+            { selected_keyboard::Keyboard::KEY_MATRIX_ROW_COUNT },
+            { selected_keyboard::Keyboard::KEY_MATRIX_COL_COUNT },
+        >,
+    >,
+    pub rotary_encoder: Option<RotaryEncoder>,
+    pub heartbeat_led: Option<HeartbeatLED>,
+    // TODO: configurable RGB matrix pinout
+    pub rgb_matrix: Option<
+        RGBMatrix<
+            { selected_keyboard::Keyboard::RGB_MATRIX_LED_COUNT },
+            Ws2812Direct<
+                pac::PIO0,
+                pio::SM0,
+                gpio::Pin<gpio::bank0::Gpio28, gpio::FunctionPio0, gpio::PullDown>,
+            >,
+        >,
+    >,
+}
+
+impl Configuration {
+    pub fn is_split(&self) -> bool {
+        self.key_matrix_split.is_some()
+    }
+}
+
+pub trait Configurator {
     const LAYER_COUNT: usize = selected_keyboard::layout::LAYER_COUNT;
     type Layer: LayerIndex = selected_keyboard::layout::Layer;
 
@@ -33,27 +76,12 @@ pub trait KeyboardConfiguration {
         slices: pwm::Slices,
         pio0: pio::PIO<pac::PIO0>,
         sm0: pio::UninitStateMachine<(pac::PIO0, pio::SM0)>,
+        uart0: pac::UART0,
+        resets: &mut pac::RESETS,
         clock_freq: HertzU32,
     ) -> (
-        Option<
-            BasicVerticalSwitchMatrix<
-                { selected_keyboard::Keyboard::KEY_MATRIX_ROW_COUNT },
-                { selected_keyboard::Keyboard::KEY_MATRIX_COL_COUNT },
-            >,
-        >,
-        Option<RotaryEncoder>,
-        Option<HeartbeatLED>,
-        // TODO: configurable RGB matrix pinout
-        Option<
-            RGBMatrix<
-                { selected_keyboard::Keyboard::RGB_MATRIX_LED_COUNT },
-                Ws2812Direct<
-                    pac::PIO0,
-                    pio::SM0,
-                    gpio::Pin<gpio::bank0::Gpio28, gpio::FunctionPio0, gpio::PullDown>,
-                >,
-            >,
-        >,
+        Configuration,
+        Option<(Arbiter<Rc<RefCell<UartSender>>>, UartReceiver)>,
     );
 
     fn get_input_map() -> InputMap<
@@ -65,5 +93,3 @@ pub trait KeyboardConfiguration {
         selected_keyboard::layout::get_input_map()
     }
 }
-
-pub use selected_keyboard::Keyboard;

--- a/src/keyboard/quadax_rift/layout/default.rs
+++ b/src/keyboard/quadax_rift/layout/default.rs
@@ -1,0 +1,77 @@
+#![allow(dead_code)]
+use defmt::Format;
+use enum_map::enum_map;
+
+use crate::{
+    key::{
+        Action::{Control as C, Key as K, LayerModifier as LM, Pass as ___________},
+        Control, Key, LayerIndex,
+    },
+    keyboard::Configurator,
+    processor::mapper::InputMap,
+    rotary::Direction,
+};
+
+pub const LAYER_COUNT: usize = 3;
+
+#[derive(Clone, Copy, Default, Format, PartialEq, PartialOrd)]
+pub enum Layer {
+    #[default]
+    Base,
+    Down,
+    Up,
+}
+
+impl LayerIndex for Layer {}
+
+impl From<Layer> for usize {
+    fn from(value: Layer) -> usize {
+        value as usize
+    }
+}
+
+#[rustfmt::skip]
+pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
+    InputMap::new(
+        [
+            [
+                [K(Key::Escape),        K(Key::Keyboard1),     K(Key::Keyboard2),     K(Key::Keyboard3),     K(Key::Keyboard4),     K(Key::Keyboard5),     ___________,           ___________,           K(Key::Keyboard6),     K(Key::Keyboard7),     K(Key::Keyboard8),     K(Key::Keyboard9),     K(Key::Keyboard0),     K(Key::DeleteBackspace)],
+                [K(Key::Tab),           K(Key::Q),             K(Key::W),             K(Key::E),             K(Key::R),             K(Key::T),             ___________,           ___________,           K(Key::Y),             K(Key::U),             K(Key::I),             K(Key::O),             K(Key::P),             K(Key::DeleteForward)],
+                [K(Key::CapsLock),      K(Key::A),             K(Key::S),             K(Key::D),             K(Key::F),             K(Key::G),             ___________,           ___________,           K(Key::H),             K(Key::J),             K(Key::K),             K(Key::L),             K(Key::Semicolon),     K(Key::ReturnEnter)],
+                [K(Key::LeftShift),     K(Key::Z),             K(Key::X),             K(Key::C),             K(Key::V),             K(Key::B),             ___________,           ___________,           K(Key::N),             K(Key::M),             K(Key::Comma),         K(Key::Dot),           K(Key::ForwardSlash),  K(Key::RightShift)],
+                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       LM(Layer::Down),       K(Key::Space),         ___________,           ___________,           K(Key::Space),         LM(Layer::Up),         K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
+            ],
+            [
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           C(Control::RGBAnimationNext), C(Control::RGBSpeedUp), C(Control::RGBBrightnessUp),           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           C(Control::RGBAnimationPrevious), C(Control::RGBSpeedDown), C(Control::RGBBrightnessDown),           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+            ],
+            [
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::LeftArrow),     K(Key::DownArrow),     K(Key::UpArrow),       K(Key::RightArrow),    ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+            ],
+        ],
+        [
+            enum_map! {
+                Direction::Clockwise => K(Key::VolumeUp),
+                Direction::CounterClockwise => K(Key::VolumeDown),
+                _ => ___________,
+            },
+            enum_map! {
+                Direction::Clockwise => C(Control::RGBBrightnessUp),
+                Direction::CounterClockwise => C(Control::RGBBrightnessDown),
+                _ => ___________,
+            },
+            enum_map! {
+                Direction::Clockwise => C(Control::RGBSpeedUp),
+                Direction::CounterClockwise => C(Control::RGBSpeedDown),
+                _ => ___________,
+            },
+        ],
+    )
+}

--- a/src/keyboard/quadax_rift/layout/mod.rs
+++ b/src/keyboard/quadax_rift/layout/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(layout = "default")]
+mod default;
+#[cfg(layout = "default")]
+use default as selected_layout;
+
+pub use selected_layout::LAYER_COUNT;
+
+pub use selected_layout::Layer;
+
+pub use selected_layout::get_input_map;

--- a/src/keyboard/quadax_rift/mod.rs
+++ b/src/keyboard/quadax_rift/mod.rs
@@ -1,0 +1,136 @@
+pub mod layout;
+
+use core::cell::RefCell;
+
+use alloc::{boxed::Box, rc::Rc};
+use hal::{
+    fugit::{HertzU32, RateExtU32},
+    gpio, pac, pio, pwm, uart,
+};
+use rtic_sync::arbiter::Arbiter;
+use ws2812_pio::Ws2812Direct;
+
+use crate::{
+    heartbeat::HeartbeatLED,
+    keyboard::{Configuration, Configurator},
+    matrix::{BasicVerticalSwitchMatrix, SplitSwitchMatrix},
+    processor::events::rgb::RGBMatrix,
+    remote::transport::uart::{UartReceiver, UartSender},
+    rotary::{Mode, RotaryEncoder},
+    split::SideDetector,
+};
+
+const ENABLE_HEARTBEAT_LED: bool = true;
+const ENABLE_KEY_MATRIX: bool = true;
+const ENABLE_ROTARY_ENCODER: bool = true;
+const ENABLE_RGB_MATRIX: bool = true;
+
+pub struct Keyboard {}
+
+impl Configurator for Keyboard {
+    const KEY_MATRIX_ROW_COUNT: usize = 5;
+    const KEY_MATRIX_COL_COUNT: usize = 14;
+
+    const RGB_MATRIX_LED_COUNT: usize = 67;
+
+    fn init(
+        pins: gpio::Pins,
+        mut slices: pwm::Slices,
+        mut pio0: pio::PIO<pac::PIO0>,
+        sm0: pio::UninitStateMachine<(pac::PIO0, pio::SM0)>,
+        uart0: pac::UART0,
+        resets: &mut pac::RESETS,
+        clock_freq: HertzU32,
+    ) -> (
+        Configuration,
+        Option<(Arbiter<Rc<RefCell<UartSender>>>, UartReceiver)>,
+    ) {
+        #[rustfmt::skip]
+        let key_matrix_split = if ENABLE_KEY_MATRIX {
+            Some(SplitSwitchMatrix::new(BasicVerticalSwitchMatrix::new(
+                [
+                    Box::new(pins.gpio10.into_pull_down_input()),
+                    Box::new(pins.gpio11.into_pull_down_input()),
+                    Box::new(pins.gpio12.into_pull_down_input()),
+                    Box::new(pins.gpio13.into_pull_down_input()),
+                    Box::new(pins.gpio14.into_pull_down_input()),
+                ],
+                [
+                    Box::new(pins.gpio3.into_push_pull_output()),
+                    Box::new(pins.gpio4.into_push_pull_output()),
+                    Box::new(pins.gpio5.into_push_pull_output()),
+                    Box::new(pins.gpio6.into_push_pull_output()),
+                    Box::new(pins.gpio7.into_push_pull_output()),
+                    Box::new(pins.gpio8.into_push_pull_output()),
+                    Box::new(pins.gpio9.into_push_pull_output()),
+                ],
+            )))
+        } else {
+            None
+        };
+
+        let rotary_encoder = if ENABLE_ROTARY_ENCODER {
+            Some(RotaryEncoder::new(
+                Box::new(pins.gpio15.into_pull_up_input()),
+                Box::new(pins.gpio17.into_pull_up_input()),
+                Box::new(pins.gpio16.into_push_pull_output()),
+                Mode::DentHighPrecision,
+            ))
+        } else {
+            None
+        };
+
+        let heartbeat_led = if ENABLE_HEARTBEAT_LED {
+            slices.pwm6.set_ph_correct();
+            slices.pwm6.enable();
+            slices.pwm6.channel_b.output_to(
+                pins.gpio29
+                    .into_push_pull_output_in_state(gpio::PinState::Low),
+            );
+            Some(HeartbeatLED::new(Box::new(slices.pwm6.channel_b)))
+        } else {
+            None
+        };
+
+        let rgb_matrix = if ENABLE_RGB_MATRIX {
+            let ws = Ws2812Direct::new(pins.gpio28.into_function(), &mut pio0, sm0, clock_freq);
+            Some(RGBMatrix::<{ Keyboard::RGB_MATRIX_LED_COUNT }, _>::new(ws))
+        } else {
+            None
+        };
+
+        let mut uart_peripheral = uart::UartPeripheral::new(
+            uart0,
+            (pins.gpio0.into_function(), pins.gpio1.into_function()),
+            resets,
+        )
+        .enable(
+            uart::UartConfig::new(
+                // 115_200.Hz(),
+                230_400.Hz(),
+                uart::DataBits::Eight,
+                None,
+                uart::StopBits::One,
+            ),
+            clock_freq,
+        )
+        .unwrap();
+        uart_peripheral.set_fifos(true);
+        let (uart_reader, uart_writer) = uart_peripheral.split();
+        let uart_sender = Arbiter::new(Rc::new(RefCell::new(UartSender::new(uart_writer))));
+        let uart_receiver = UartReceiver::new(uart_reader);
+
+        SideDetector::new(Box::new(pins.gpio2.into_pull_down_input())).detect();
+
+        (
+            Configuration {
+                key_matrix: None,
+                key_matrix_split,
+                rotary_encoder,
+                heartbeat_led,
+                rgb_matrix,
+            },
+            Some((uart_sender, uart_receiver)),
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![feature(associated_type_defaults)]
 #![feature(trait_alias)]
 #![allow(clippy::type_complexity)]
+mod debug;
 mod heartbeat;
 mod key;
 mod keyboard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,26 @@
 #![feature(type_alias_impl_trait)]
 #![feature(associated_type_defaults)]
 #![feature(trait_alias)]
+#![feature(async_closure)]
+#![feature(generic_const_exprs)]
+#![feature(future_join)]
+#![allow(incomplete_features)]
+#![allow(refining_impl_trait)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::await_holding_refcell_ref)]
 mod debug;
 mod heartbeat;
 mod key;
 mod keyboard;
 mod matrix;
 mod processor;
+mod remote;
 mod rotary;
+mod split;
 mod util;
 
+#[macro_use]
 extern crate alloc;
 extern crate rp2040_hal as hal;
 use {defmt_rtt as _, panic_probe as _};
@@ -22,29 +32,31 @@ use {defmt_rtt as _, panic_probe as _};
     dispatchers = [TIMER_IRQ_1, TIMER_IRQ_2, TIMER_IRQ_3]
 )]
 mod kb {
-    use alloc::{boxed::Box, vec::Vec};
-    #[global_allocator]
-    static HEAP: embedded_alloc::Heap = embedded_alloc::Heap::empty();
-
-    use defmt::{debug, info};
-
     // The linker will place this boot block at the start of our program image.
     // We need this to help the ROM bootloader get our code up and running.
     #[link_section = ".boot2"]
     #[used]
     pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
+    #[global_allocator]
+    pub static HEAP: embedded_alloc::Heap = embedded_alloc::Heap::empty();
+    const HEAP_SIZE_BYTES: usize = 16384; // 16 KB
+    static mut HEAP_MEM: [core::mem::MaybeUninit<u8>; HEAP_SIZE_BYTES] =
+        [core::mem::MaybeUninit::uninit(); HEAP_SIZE_BYTES];
+
+    use alloc::{boxed::Box, rc::Rc, vec::Vec};
+    use core::cell::RefCell;
     use hal::{
         clocks::init_clocks_and_plls,
         gpio, pac,
         pio::{self, PIOExt},
         pwm, sio, usb, Clock, Sio, Watchdog,
     };
-
     use rtic_monotonics::rp2040::prelude::*;
-    rp2040_timer_monotonic!(Mono);
-
-    use rtic_sync::channel::{Receiver, Sender};
+    use rtic_sync::{
+        arbiter::Arbiter,
+        channel::{Receiver, Sender},
+    };
     use usb_device::{class_prelude::*, prelude::*, UsbError};
     use usbd_human_interface_device::{
         device::keyboard::{NKROBootKeyboard, NKROBootKeyboardConfig},
@@ -53,18 +65,30 @@ mod kb {
     };
 
     use crate::{
+        debug,
         heartbeat::HeartbeatLED,
         key::{Action, Edge, Key},
-        keyboard::{Keyboard, KeyboardConfiguration},
-        matrix::{BasicVerticalSwitchMatrix, Scanner},
+        keyboard::{Configuration, Configurator, Keyboard},
+        matrix::{SplitScanner, SplitSwitchMatrix},
         processor::{
             events::rgb::{FrameIterator, RGBMatrix, RGBProcessor},
             input::debounce::KeyMatrixRisingFallingDebounceProcessor,
             mapper::{Input, Mapper},
             Event, EventsProcessor, InputProcessor,
         },
+        remote::{
+            self,
+            transport::{
+                uart::{UartReceiver, UartSender},
+                Sequence, TransportReceiver,
+            },
+            Server,
+        },
         rotary::RotaryEncoder,
+        split,
     };
+
+    rp2040_timer_monotonic!(Mono);
 
     const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;
 
@@ -78,63 +102,33 @@ mod kb {
     const HID_REPORTER_TARGET_POLL_PERIOD_MICROS: u64 =
         1_000_000u64 / HID_REPORTER_TARGET_POLL_FREQ;
 
-    const DEBUG_LOG_INPUT_SCANNER_ENABLE_TIMING: bool = false;
-    const DEBUG_LOG_INPUT_SCANNER_INTERVAL: u64 = 50;
-    const DEBUG_LOG_PROCESSOR_ENABLE_TIMING: bool = false;
-    const DEBUG_LOG_PROCESSOR_INTERVAL: u64 = 50;
-    const DEBUG_LOG_EVENTS: bool = true;
-    const DEBUG_LOG_SENT_KEYS: bool = false;
-
     #[shared]
     struct Shared {
+        is_usb_connected: bool,
         usb_device: UsbDevice<'static, usb::UsbBus>,
         usb_keyboard: UsbHidClass<
             'static,
             usb::UsbBus,
             frunk::HList!(NKROBootKeyboard<'static, usb::UsbBus>),
         >,
+        transport_sender: Option<Arbiter<Rc<RefCell<UartSender>>>>,
     }
 
     #[local]
     struct Local {
-        key_matrix: Option<
-            BasicVerticalSwitchMatrix<
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT },
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT },
-            >,
-        >,
-        rotary_encoder: Option<RotaryEncoder>,
-        heartbeat_led: Option<HeartbeatLED>,
-        rgb_matrix: Option<
-            RGBMatrix<
-                { <Keyboard as KeyboardConfiguration>::RGB_MATRIX_LED_COUNT },
-                ws2812_pio::Ws2812Direct<
-                    pac::PIO0,
-                    pio::SM0,
-                    gpio::Pin<gpio::bank0::Gpio28, gpio::FunctionPio0, gpio::PullDown>,
-                >,
-            >,
-        >,
+        transport_receiver: Option<UartReceiver>,
     }
 
     #[init(local = [usb_allocator: Option<UsbBusAllocator<usb::UsbBus>> = None])]
     fn init(mut ctx: init::Context) -> (Shared, Local) {
-        info!("init()");
+        defmt::info!("init()");
 
         // Soft-reset does not release the hardware spinlocks.
         // Release them now to avoid a deadlock after debug or watchdog reset.
-        unsafe {
-            sio::spinlock_reset();
-        }
+        unsafe { sio::spinlock_reset() };
 
         // Initialize global memory allocator
-        {
-            use core::mem::MaybeUninit;
-            const HEAP_COUNT: usize = 2048;
-            static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_COUNT] =
-                [MaybeUninit::uninit(); HEAP_COUNT];
-            unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_COUNT) }
-        }
+        unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE_BYTES) };
 
         // Set the ARM SLEEPONEXIT bit to go to sleep after handling interrupts
         // See https://developer.arm.com/docs/100737/0100/power-management/sleep-mode/sleep-on-exit-bit
@@ -156,13 +150,13 @@ mod kb {
         .unwrap();
 
         // Init channels
-        let (input_sender, input_receiver) = rtic_sync::make_channel!(Input<{<Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT}, {<Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT}>, INPUT_CHANNEL_BUFFER_SIZE);
+        let (input_sender, input_receiver) = rtic_sync::make_channel!(Input<{<Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT}, {<Keyboard as Configurator>::KEY_MATRIX_COL_COUNT}>, INPUT_CHANNEL_BUFFER_SIZE);
         let (keys_sender, keys_receiver) =
             rtic_sync::make_channel!(Vec<Key>, KEYS_CHANNEL_BUFFER_SIZE);
         let (frame_sender, frame_receiver) = rtic_sync::make_channel!(Box<dyn FrameIterator>, 1);
 
         // Init HID device
-        info!("init usb allocator");
+        defmt::info!("init usb allocator");
         let usb_allocator = ctx
             .local
             .usb_allocator
@@ -174,12 +168,12 @@ mod kb {
                 &mut ctx.device.RESETS,
             )));
 
-        info!("init usb keyboard");
+        defmt::info!("init usb keyboard");
         let usb_keyboard = UsbHidClassBuilder::new()
             .add_device(NKROBootKeyboardConfig::default())
             .build(usb_allocator);
 
-        info!("init usb device");
+        defmt::info!("init usb device");
         let usb_device = UsbDeviceBuilder::new(usb_allocator, UsbVidPid(0x1111, 0x1111))
             .strings(&[StringDescriptors::default()
                 .manufacturer("daystram")
@@ -190,7 +184,7 @@ mod kb {
 
         // Init keyboard
         let (pio0, sm0, _, _, _) = ctx.device.PIO0.split(&mut ctx.device.RESETS);
-        let (key_matrix, rotary_encoder, heartbeat_led, rgb_matrix) = Keyboard::init(
+        let (config, transport) = Keyboard::init(
             gpio::Pins::new(
                 ctx.device.IO_BANK0,
                 ctx.device.PADS_BANK0,
@@ -200,71 +194,217 @@ mod kb {
             pwm::Slices::new(ctx.device.PWM, &mut ctx.device.RESETS),
             pio0,
             sm0,
+            ctx.device.UART0,
+            &mut ctx.device.RESETS,
             clocks.peripheral_clock.freq(),
         );
+        assert!(
+            !config.is_split() || transport.is_some(),
+            "keyboard is configured as split but remote transport is not configured"
+        );
 
-        heartbeat::spawn().ok();
-        input_scanner::spawn(input_sender).ok();
-        processor::spawn(input_receiver, keys_sender, frame_sender).ok();
-        rgb_matrix_renderer::spawn(frame_receiver).ok();
-        hid_usb_tick::spawn().ok();
-        hid_reporter::spawn(keys_receiver).ok();
-
-        info!("enable interrupts");
-        unsafe {
-            pac::NVIC::unmask(pac::Interrupt::USBCTRL_IRQ);
+        let (transport_sender, mut transport_receiver) = match transport {
+            Some((transport_sender, transport_receiver)) => {
+                (Some(transport_sender), Some(transport_receiver))
+            }
+            None => (None, None),
         };
 
-        info!("init() done");
+        // Start
+        start_wait_usb::spawn(
+            1.secs(),
+            input_sender,
+            input_receiver,
+            keys_sender,
+            keys_receiver,
+            frame_sender,
+            frame_receiver,
+            transport_receiver
+                .as_mut()
+                .map(|transport_receiver| transport_receiver.initialize_seq_sender()),
+            config,
+        )
+        .ok();
+
+        defmt::info!("init() done");
         (
             Shared {
+                is_usb_connected: false,
                 usb_device,
                 usb_keyboard,
+                transport_sender,
             },
-            Local {
-                key_matrix,
-                rotary_encoder,
-                heartbeat_led,
-                rgb_matrix,
-            },
+            Local { transport_receiver },
         )
     }
 
     #[idle()]
-    fn idle(_ctx: idle::Context) -> ! {
-        info!("idle()");
+    fn idle(_: idle::Context) -> ! {
+        defmt::info!("idle()");
         loop {
             // https://developer.arm.com/documentation/ddi0406/c/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/WFI
             rtic::export::wfi()
         }
     }
 
-    #[task (local=[key_matrix, rotary_encoder], priority = 1)]
-    async fn input_scanner(
-        ctx: input_scanner::Context,
+    // ============================= Master and Slave
+    #[task(shared=[is_usb_connected], priority = 1)]
+    async fn start_wait_usb(
+        mut ctx: start_wait_usb::Context,
+        timeout: <Mono as Monotonic>::Duration,
+        input_sender: Sender<
+            'static,
+            Input<
+                { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+            >,
+            INPUT_CHANNEL_BUFFER_SIZE,
+        >,
+        input_receiver: Receiver<
+            'static,
+            Input<
+                { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+            >,
+            INPUT_CHANNEL_BUFFER_SIZE,
+        >,
+        keys_sender: Sender<'static, Vec<Key>, KEYS_CHANNEL_BUFFER_SIZE>,
+        keys_receiver: Receiver<'static, Vec<Key>, KEYS_CHANNEL_BUFFER_SIZE>,
+        frame_sender: Sender<'static, Box<dyn FrameIterator>, 1>,
+        frame_receiver: Receiver<'static, Box<dyn FrameIterator>, 1>,
+        seq_sender: Option<Receiver<'static, Sequence, { remote::REQUEST_SEQUENCE_QUEUE_SIZE }>>,
+        config: Configuration,
+    ) {
+        defmt::info!("start_wait_usb()");
+
+        // Start USB tasks
+        hid_usb_tick::spawn().ok();
+        hid_reporter::spawn(keys_receiver).ok();
+        unsafe { hal::pac::NVIC::unmask(hal::pac::Interrupt::USBCTRL_IRQ) }
+
+        Mono::delay(timeout).await;
+
+        split::set_self_mode(ctx.shared.is_usb_connected.lock(|is_usb_connected| {
+            if *is_usb_connected {
+                split::Mode::Master
+            } else {
+                split::Mode::Slave
+            }
+        }));
+        defmt::warn!(
+            "detected as {} {}",
+            split::get_self_mode(),
+            split::get_self_side()
+        );
+
+        match split::get_self_mode() {
+            split::Mode::Master => {
+                heartbeat::spawn(config.heartbeat_led, 500.millis()).ok();
+                master_input_scanner::spawn(
+                    config.key_matrix_split,
+                    config.rotary_encoder,
+                    input_sender,
+                )
+                .ok();
+                master_processor::spawn(input_receiver, keys_sender, frame_sender).ok();
+                rgb_matrix_renderer::spawn(config.rgb_matrix, frame_receiver).ok();
+            }
+            split::Mode::Slave => {
+                assert!(
+                    config.is_split(),
+                    "keyboard is not configured to operate as split"
+                );
+
+                // Initialize server and register services
+                let mut server = Server::new(seq_sender.unwrap());
+                if let Some(key_matrix_split) = config.key_matrix_split {
+                    server.register_service(Box::new(key_matrix_split)).await;
+                }
+
+                heartbeat::spawn(config.heartbeat_led, 2000.millis()).ok();
+                slave_server::spawn(server).ok();
+            }
+        }
+        unsafe { hal::pac::NVIC::unmask(hal::pac::Interrupt::UART0_IRQ) }
+    }
+
+    #[task(priority = 2)]
+    async fn heartbeat(
+        _: heartbeat::Context,
+        mut heartbeat_led: Option<HeartbeatLED>,
+        period: <Mono as Monotonic>::Duration,
+    ) {
+        defmt::info!("heartbeat()");
+        if let Some(ref mut heartbeat_led) = heartbeat_led {
+            heartbeat_led.cycle(period).await
+        };
+    }
+
+    #[task(binds = UART0_IRQ, local = [transport_receiver], priority = 1)]
+    fn receive_uart(ctx: receive_uart::Context) {
+        match ctx.local.transport_receiver {
+            Some(transport_receiver) => {
+                let start_time = Mono::now();
+                transport_receiver.read_into_buffer();
+                let end_time = Mono::now();
+                debug::log_duration(
+                    debug::LogDurationTag::UARTIRQRecieveBuffer,
+                    start_time,
+                    end_time,
+                );
+            }
+            None => {}
+        }
+    }
+    // ============================= Master and Slave
+
+    // ============================= Slave
+    #[task (shared=[&transport_sender], priority = 1)]
+    async fn slave_server(ctx: slave_server::Context, mut server: Server) {
+        defmt::info!("slave_server()");
+        server
+            .listen(ctx.shared.transport_sender.as_ref().unwrap())
+            .await;
+    }
+    // ============================= Slave
+
+    // ============================= Master
+    #[task (shared=[&transport_sender], priority = 1)]
+    async fn master_input_scanner(
+        ctx: master_input_scanner::Context,
+        mut key_matrix_split: Option<
+            SplitSwitchMatrix<
+                { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+            >,
+        >,
+        mut rotary_encoder: Option<RotaryEncoder>,
         mut input_sender: Sender<
             'static,
             Input<
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT },
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
             >,
             INPUT_CHANNEL_BUFFER_SIZE,
         >,
     ) {
-        info!("input_scanner()");
+        defmt::info!("master_input_scanner()");
         let mut poll_end_time = Mono::now();
         let mut n: u64 = 0;
         loop {
             let scan_start_time = Mono::now();
-            let key_matrix_result = match ctx.local.key_matrix {
-                Some(key_matrix) => key_matrix.scan().await,
-                None => Default::default(),
-            };
-            let rotary_encoder_result = match ctx.local.rotary_encoder {
-                Some(rotary_encoder) => rotary_encoder.scan(),
-                None => Default::default(),
-            };
 
+            let transport_sender = ctx.shared.transport_sender.as_ref();
+            let key_matrix_result = match key_matrix_split {
+                Some(ref mut key_matrix_split) => {
+                    key_matrix_split.scan(transport_sender.unwrap()).await
+                }
+                None => Default::default(),
+            };
+            let rotary_encoder_result = match rotary_encoder {
+                Some(ref mut rotary_encoder) => rotary_encoder.scan(),
+                None => Default::default(),
+            };
             input_sender
                 .try_send(Input {
                     key_matrix_result,
@@ -272,9 +412,11 @@ mod kb {
                 })
                 .ok(); // drop data if buffer is full
 
-            if DEBUG_LOG_INPUT_SCANNER_ENABLE_TIMING && n % DEBUG_LOG_INPUT_SCANNER_INTERVAL == 0 {
+            if debug::ENABLE_LOG_INPUT_SCANNER_ENABLE_TIMING
+                && n % debug::LOG_INPUT_SCANNER_SAMPLING_RATE == 0
+            {
                 let scan_end_time = Mono::now();
-                debug!(
+                defmt::debug!(
                     "[{}] input_scanner: {} us\tpoll: {} us\trate: {} Hz\t budget: {} %",
                     n,
                     (scan_end_time - scan_start_time).to_micros(),
@@ -286,6 +428,13 @@ mod kb {
             }
 
             poll_end_time = Mono::now();
+            debug::log_duration(
+                debug::LogDurationTag::ClientInputScan,
+                scan_start_time,
+                poll_end_time,
+            );
+            debug::log_heap();
+
             n = n.wrapping_add(1);
             Mono::delay_until(scan_start_time + INPUT_SCANNER_TARGET_POLL_PERIOD_MICROS.micros())
                 .await;
@@ -293,31 +442,31 @@ mod kb {
     }
 
     #[task(priority = 2)]
-    async fn processor(
-        _: processor::Context,
+    async fn master_processor(
+        _: master_processor::Context,
         mut input_receiver: Receiver<
             'static,
             Input<
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT },
-                { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+                { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
             >,
             INPUT_CHANNEL_BUFFER_SIZE,
         >,
         mut keys_sender: Sender<'static, Vec<Key>, KEYS_CHANNEL_BUFFER_SIZE>,
         frame_sender: Sender<'static, Box<dyn FrameIterator>, 1>,
     ) {
-        info!("processor()");
+        defmt::info!("master_processor()");
         let input_processors: &mut [&mut dyn InputProcessor<
-            { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_ROW_COUNT },
-            { <Keyboard as KeyboardConfiguration>::KEY_MATRIX_COL_COUNT },
+            { <Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+            { <Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
         >] = &mut [&mut KeyMatrixRisingFallingDebounceProcessor::new(
             10.millis(),
         )];
-        let mut mapper = Mapper::new(<Keyboard as KeyboardConfiguration>::get_input_map());
+        let mut mapper = Mapper::new(<Keyboard as Configurator>::get_input_map());
         let events_processors: &mut [&mut dyn EventsProcessor<
-            <Keyboard as KeyboardConfiguration>::Layer,
+            <Keyboard as Configurator>::Layer,
         >] = &mut [&mut RGBProcessor::<
-            { <Keyboard as KeyboardConfiguration>::RGB_MATRIX_LED_COUNT },
+            { <Keyboard as Configurator>::RGB_MATRIX_LED_COUNT },
         >::new(frame_sender)];
 
         let mut poll_end_time = Mono::now();
@@ -332,15 +481,16 @@ mod kb {
                 continue;
             }
 
-            let mut events =
-                Vec::<Event<<Keyboard as KeyboardConfiguration>::Layer>>::with_capacity(10);
+            let mut events = Vec::<Event<<Keyboard as Configurator>::Layer>>::with_capacity(10);
             mapper.map(&input, &mut events);
 
-            if DEBUG_LOG_EVENTS {
+            if debug::ENABLE_LOG_EVENTS {
                 events
                     .iter()
                     .filter(|e| e.edge != Edge::None)
-                    .for_each(|e| debug!("[{}] event: action: {} edge: {}", n, e.action, e.edge));
+                    .for_each(|e| {
+                        defmt::debug!("[{}] event: action: {} edge: {}", n, e.action, e.edge)
+                    });
             }
 
             if events_processors
@@ -363,9 +513,11 @@ mod kb {
                 )
                 .ok(); // drop data if buffer is full
 
-            if DEBUG_LOG_PROCESSOR_ENABLE_TIMING && (n % DEBUG_LOG_PROCESSOR_INTERVAL == 0) {
+            if debug::ENABLE_LOG_PROCESSOR_ENABLE_TIMING
+                && (n % debug::LOG_PROCESSOR_SAMPLING_RATE == 0)
+            {
                 let scan_end_time = Mono::now();
-                debug!(
+                defmt::debug!(
                     "[{}] processor: {} us\tpoll: {} us\trate: {} Hz\t budget: {} %",
                     n,
                     (scan_end_time - process_start_time).to_micros(),
@@ -381,16 +533,37 @@ mod kb {
         }
     }
 
-    #[task(shared=[usb_keyboard], priority = 1)]
+    #[task(priority = 3)]
+    async fn rgb_matrix_renderer(
+        _: rgb_matrix_renderer::Context,
+        mut rgb_matrix: Option<
+            RGBMatrix<
+                { <Keyboard as Configurator>::RGB_MATRIX_LED_COUNT },
+                ws2812_pio::Ws2812Direct<
+                    pac::PIO0,
+                    pio::SM0,
+                    gpio::Pin<gpio::bank0::Gpio28, gpio::FunctionPio0, gpio::PullDown>,
+                >,
+            >,
+        >,
+        frame_receiver: Receiver<'static, Box<dyn FrameIterator>, 1>,
+    ) {
+        defmt::info!("rgb_matrix_renderer()");
+        if let Some(ref mut rgb_matrix) = rgb_matrix {
+            rgb_matrix.render(frame_receiver).await;
+        }
+    }
+
+    #[task(shared=[usb_keyboard], priority = 2)]
     async fn hid_reporter(
         mut ctx: hid_reporter::Context,
         mut keys_receiver: Receiver<'static, Vec<Key>, KEYS_CHANNEL_BUFFER_SIZE>,
     ) {
-        info!("hid_reporter()");
+        defmt::info!("hid_reporter()");
         while let Ok(keys) = keys_receiver.recv().await {
             let start_time = Mono::now();
-            if DEBUG_LOG_SENT_KEYS {
-                debug!("keys: {:?}", keys.as_slice());
+            if debug::ENABLE_LOG_SENT_KEYS {
+                defmt::debug!("keys: {:?}", keys.as_slice());
             }
 
             ctx.shared.usb_keyboard.lock(|k| {
@@ -408,14 +581,15 @@ mod kb {
         }
     }
 
-    #[task(binds = USBCTRL_IRQ, shared = [usb_device, usb_keyboard], priority = 1)]
+    #[task(binds = USBCTRL_IRQ, shared = [usb_device, usb_keyboard, is_usb_connected], priority = 2)]
     fn hid_reader(ctx: hid_reader::Context) {
-        (ctx.shared.usb_device, ctx.shared.usb_keyboard).lock(|usb_device, usb_keyboard| {
+        (ctx.shared.usb_device, ctx.shared.usb_keyboard, ctx.shared.is_usb_connected).lock(|usb_device, usb_keyboard, is_usb_connected| {
             if usb_device.poll(&mut [usb_keyboard]) {
+                *is_usb_connected = true; // usb connection detected
                 match usb_keyboard.device().read_report() {
                     Ok(leds) => {
-                        debug!(
-                            "num_lock: {}\ncaps_lock: {}\nscroll_lock: {}\ncompose: {}\nkana: {}\n",
+                        defmt::debug!(
+                            "\nnum_lock: {}\ncaps_lock: {}\nscroll_lock: {}\ncompose: {}\nkana: {}\n",
                             leds.num_lock,
                             leds.caps_lock,
                             leds.scroll_lock,
@@ -434,10 +608,10 @@ mod kb {
 
     #[task(
         shared = [usb_keyboard],
-        priority = 1,
+        priority = 2,
     )]
     async fn hid_usb_tick(mut ctx: hid_usb_tick::Context) {
-        info!("hid_usb_tick()");
+        defmt::info!("hid_usb_tick()");
         loop {
             ctx.shared.usb_keyboard.lock(|k| match k.tick() {
                 Ok(_) => {}
@@ -449,26 +623,5 @@ mod kb {
             Mono::delay(1.millis()).await;
         }
     }
-
-    #[task(local=[heartbeat_led], priority = 1)]
-    async fn heartbeat(ctx: heartbeat::Context) {
-        info!("heartbeat()");
-        match ctx.local.heartbeat_led {
-            Some(heartbeat_led) => heartbeat_led.cycle().await,
-            None => {}
-        }
-    }
-    #[task(local=[rgb_matrix], priority = 3)]
-    async fn rgb_matrix_renderer(
-        ctx: rgb_matrix_renderer::Context,
-        frame_receiver: Receiver<'static, Box<dyn FrameIterator>, 1>,
-    ) {
-        info!("rgb_matrix_renderer()");
-        match ctx.local.rgb_matrix {
-            Some(rgb_matrix) => {
-                rgb_matrix.render(frame_receiver).await;
-            }
-            None => {}
-        }
-    }
+    // ============================= Master
 }

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,0 +1,131 @@
+pub mod transport;
+
+use alloc::{boxed::Box, rc::Rc, vec::Vec};
+use async_trait::async_trait;
+use core::cell::{LazyCell, RefCell};
+use defmt::Format;
+use rtic_monotonics::Monotonic;
+use rtic_sync::{arbiter::Arbiter, channel::Receiver};
+use serde::{Deserialize, Serialize};
+use transport::{Sequence, TransportSender};
+
+use crate::{debug, kb::Mono};
+
+pub const REQUEST_SEQUENCE_QUEUE_SIZE: usize = 1;
+
+static SERVICE_REGISTRY: Arbiter<
+    LazyCell<Rc<RefCell<[Option<Box<dyn Service>>; ServiceId::MAX as usize + 1]>>>,
+> = Arbiter::new(LazyCell::new(|| {
+    Rc::new(RefCell::new([const { None }; ServiceId::MAX as usize + 1]))
+}));
+
+pub type ServiceId = u8;
+pub type MethodId = u8;
+
+#[async_trait(?Send)]
+pub trait Service {
+    fn get_service_id(&self) -> ServiceId;
+    async fn dispatch(&mut self, method_id: MethodId, request: &[u8]) -> Result<Vec<u8>, Error>;
+}
+
+#[derive(Clone, Copy, Debug, Format, PartialEq)]
+pub enum Error {
+    ResponseSerializationFailed,
+    MethodUnimplemented,
+}
+
+pub struct Server {
+    seq_receiver: Receiver<'static, Sequence, REQUEST_SEQUENCE_QUEUE_SIZE>,
+}
+
+impl Server {
+    pub fn new(seq_receiver: Receiver<'static, Sequence, REQUEST_SEQUENCE_QUEUE_SIZE>) -> Self {
+        Server { seq_receiver }
+    }
+
+    pub async fn register_service(&mut self, service: Box<dyn Service>) {
+        let service_id = service.get_service_id();
+        SERVICE_REGISTRY.access().await.as_ref().borrow_mut()[service_id as usize] = Some(service);
+    }
+
+    pub async fn listen<S>(&mut self, sender: &Arbiter<Rc<RefCell<S>>>)
+    where
+        S: TransportSender,
+    {
+        while let Ok(sequence) = self.seq_receiver.recv().await {
+            let start_time_listen = Mono::now();
+            let c = sender.access().await;
+            let mut client = c.as_ref().borrow_mut();
+
+            // retrieve request
+            let start_time_retrieve = Mono::now();
+            let (service_id, method_id, req, mut respond) = match client.get_payload(sequence) {
+                Ok(r) => r,
+                Err(err) => {
+                    defmt::error!("failed to retrieve request payload: {}", err);
+                    return;
+                }
+            };
+            let end_time_retrieve = Mono::now();
+            debug::log_duration(
+                debug::LogDurationTag::ServerListenRetrieve,
+                start_time_retrieve,
+                end_time_retrieve,
+            );
+
+            // dispatch
+            let start_time_dispatch = Mono::now();
+            let res = match match SERVICE_REGISTRY.access().await.as_ref().borrow_mut()
+                [service_id as usize]
+            {
+                Some(ref mut service) => service.dispatch(method_id, req).await,
+                None => {
+                    defmt::error!("service not implemented: service_id={}", service_id);
+                    return;
+                }
+            } {
+                Ok(res) => res,
+                Err(err) => {
+                    defmt::error!("failed to execute method: {}", err);
+                    return;
+                }
+            };
+            let end_time_dispatch = Mono::now();
+            debug::log_duration(
+                debug::LogDurationTag::ServerListenDispatch,
+                start_time_dispatch,
+                end_time_dispatch,
+            );
+
+            // return response
+            let start_time_respond = Mono::now();
+            respond(&res);
+            let end_time_respond = Mono::now();
+            debug::log_duration(
+                debug::LogDurationTag::ServerListenRespond,
+                start_time_respond,
+                end_time_respond,
+            );
+
+            let end_time_listen = Mono::now();
+            debug::log_duration(
+                debug::LogDurationTag::ServerListenFull,
+                start_time_listen,
+                end_time_listen,
+            );
+            debug::log_heap();
+        }
+    }
+}
+
+pub trait RemoteInvoker {
+    fn invoke<'b, Q, R>(
+        &mut self,
+        service_id: ServiceId,
+        method_id: MethodId,
+        request: Q,
+    ) -> impl core::future::Future<Output = R>
+    where
+        Q: Serialize,
+        R: Deserialize<'b>;
+}

--- a/src/remote/transport/mod.rs
+++ b/src/remote/transport/mod.rs
@@ -1,0 +1,76 @@
+pub mod uart;
+
+use alloc::vec::Vec;
+use core::future::Future;
+use defmt::Format;
+use rtic_sync::channel::Receiver;
+use serde::{Deserialize, Serialize};
+
+use super::{MethodId, ServiceId};
+
+#[derive(Clone, Copy, Debug, Deserialize, Format, PartialEq, Serialize)]
+#[repr(u8)]
+enum Kind {
+    Request,
+    Response,
+}
+
+pub type Sequence = u8;
+
+#[derive(Clone, Copy, Debug, Deserialize, Format, Serialize)]
+pub struct Packet<'a> {
+    kind: Kind,
+    pub sequence: Sequence,
+    pub service_id: super::ServiceId,
+    pub method_id: super::MethodId,
+    pub payload: &'a [u8],
+}
+
+/*
+    Packet bit layout
+         0   1   2   3   4   5   6   7
+       +---+---+---+---+---+---+---+---+
+    0  |            length             |
+       +---+---+---+---+---+---+---+---+
+    8  |             kind              |
+       +---+---+---+---+---+---+---+---+
+   16  |           sequence            |
+       +---+---+---+---+---+---+---+---+
+   24  |          service_id           |
+       +---+---+---+---+---+---+---+---+
+   32  |          method_id            |
+       +---+---+---+---+---+---+---+---+
+   40  |                               |
+    .  |                               |
+    .  |           payload             |
+    .  |                               |
+    N  |                               |
+       +---+---+---+---+---+---+---+---+
+*/
+
+pub trait TransportReceiver {
+    fn initialize_seq_sender(
+        &mut self,
+    ) -> Receiver<'static, Sequence, { super::REQUEST_SEQUENCE_QUEUE_SIZE }>;
+    fn read_into_buffer(&mut self);
+}
+
+pub trait TransportSender {
+    fn send_request(
+        &mut self,
+        service_id: super::ServiceId,
+        method_id: super::MethodId,
+        payload: &[u8],
+    ) -> Sequence;
+    fn get_payload(
+        &mut self,
+        sequence: Sequence,
+    ) -> Result<(ServiceId, MethodId, &[u8], impl FnMut(&[u8])), Error>;
+    fn receive_response_poll(&mut self, sequence: Sequence)
+        -> impl Future<Output = Vec<u8>> + Send;
+}
+
+#[derive(Clone, Copy, Debug, Format, PartialEq)]
+pub enum Error {
+    MissingPacketBuffer,
+}

--- a/src/remote/transport/uart.rs
+++ b/src/remote/transport/uart.rs
@@ -1,0 +1,326 @@
+use core::cell::RefCell;
+
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
+use cortex_m::interrupt::Mutex;
+use embedded_io::Write;
+use hal::{
+    gpio,
+    uart::{Reader, Writer},
+};
+use rtic_monotonics::{rp2040::prelude::*, Monotonic};
+use rtic_sync::channel::{Receiver, Sender};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    debug,
+    kb::Mono,
+    remote::{transport::Sequence, MethodId, RemoteInvoker, ServiceId},
+};
+
+use super::{Kind, Packet, TransportReceiver, TransportSender};
+
+const UART_FRAME_BUFFER_SIZE_BYTES: usize = 256;
+
+static PACKET_BUFFER: Mutex<RefCell<[Option<Packet>; Sequence::MAX as usize + 1]>> =
+    Mutex::new(RefCell::new([None; Sequence::MAX as usize + 1]));
+
+pub struct UartReceiver {
+    uart_reader: Reader<
+        hal::pac::UART0,
+        (
+            gpio::Pin<gpio::bank0::Gpio0, gpio::FunctionUart, gpio::PullDown>,
+            gpio::Pin<gpio::bank0::Gpio1, gpio::FunctionUart, gpio::PullDown>,
+        ),
+    >,
+    seq_sender: Option<Sender<'static, Sequence, { super::super::REQUEST_SEQUENCE_QUEUE_SIZE }>>,
+}
+
+impl UartReceiver {
+    pub fn new(
+        mut uart_reader: Reader<
+            hal::pac::UART0,
+            (
+                gpio::Pin<gpio::bank0::Gpio0, gpio::FunctionUart, gpio::PullDown>,
+                gpio::Pin<gpio::bank0::Gpio1, gpio::FunctionUart, gpio::PullDown>,
+            ),
+        >,
+    ) -> Self {
+        uart_reader.enable_rx_interrupt();
+        UartReceiver {
+            uart_reader,
+            seq_sender: None,
+        }
+    }
+}
+
+impl TransportReceiver for UartReceiver {
+    fn initialize_seq_sender(
+        &mut self,
+    ) -> Receiver<'static, Sequence, { super::super::REQUEST_SEQUENCE_QUEUE_SIZE }> {
+        let (seq_sender, seq_receiver) =
+            rtic_sync::make_channel!(Sequence, { super::super::REQUEST_SEQUENCE_QUEUE_SIZE });
+        self.seq_sender = Some(seq_sender);
+        seq_receiver
+    }
+
+    fn read_into_buffer(&mut self) {
+        let start_time_read = Mono::now();
+        let mut buffer = [0u8; UART_FRAME_BUFFER_SIZE_BYTES];
+        let mut offset = 0;
+
+        match self.uart_reader.read_raw(&mut buffer[offset..]) {
+            Ok(n) => {
+                offset += n;
+            }
+            Err(_) => return, // fails on first read, drop
+        }
+
+        let expected_length = buffer[0] as usize;
+        if expected_length == 0 {
+            return;
+        }
+        if expected_length > buffer.len() {
+            defmt::error!(
+                "expected packet overflows buffer: expected_len={}",
+                expected_length
+            )
+        }
+
+        while offset < expected_length {
+            match self.uart_reader.read_raw(&mut buffer[offset..]) {
+                Ok(n) => {
+                    offset += n;
+                }
+                Err(nb::Error::WouldBlock) => continue,
+                Err(_) => return, // unhandled
+            }
+        }
+        if offset == 0 {
+            return;
+        }
+        let end_time_read = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTReceiverReadRead,
+            start_time_read,
+            end_time_read,
+        );
+
+        let start_time_deserialize = Mono::now();
+        let packet: Packet =
+            postcard::from_bytes_cobs(&mut buffer[1..expected_length + 1]).unwrap();
+        let end_time_deserialize = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTReceiverReadDeserialize,
+            start_time_deserialize,
+            end_time_deserialize,
+        );
+
+        let start_time_buffer = Mono::now();
+        cortex_m::interrupt::free(|cs| {
+            if let Some(ref mut old_packet) =
+                PACKET_BUFFER.borrow(cs).borrow_mut()[packet.sequence as usize]
+            {
+                // defmt::warn!("dropping on wrap: size={}B", mem::size_of_val(old_packet));
+                drop(unsafe { Box::from_raw(old_packet.payload as *const [u8] as *mut [u8]) });
+            }
+            PACKET_BUFFER.borrow(cs).borrow_mut()[packet.sequence as usize] = Some(Packet {
+                kind: packet.kind,
+                sequence: packet.sequence,
+                service_id: packet.service_id,
+                method_id: packet.method_id,
+                payload: Box::leak(packet.payload.to_owned().into_boxed_slice()),
+            });
+        });
+        let end_time_buffer = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTReceiverReadBuffer,
+            start_time_buffer,
+            end_time_buffer,
+        );
+
+        if packet.kind == super::Kind::Request {
+            if let Some(ref mut seq_sender) = self.seq_sender {
+                if seq_sender.try_send(packet.sequence).is_err() {
+                    defmt::error!(
+                        "request sequence queue is full, request dropped: seq={}",
+                        packet.sequence
+                    );
+                };
+            }
+        }
+    }
+}
+
+pub struct UartSender {
+    uart_writer: Writer<
+        hal::pac::UART0,
+        (
+            gpio::Pin<gpio::bank0::Gpio0, gpio::FunctionUart, gpio::PullDown>,
+            gpio::Pin<gpio::bank0::Gpio1, gpio::FunctionUart, gpio::PullDown>,
+        ),
+    >,
+}
+
+impl UartSender {
+    pub fn new(
+        mut uart_writer: Writer<
+            hal::pac::UART0,
+            (
+                gpio::Pin<gpio::bank0::Gpio0, gpio::FunctionUart, gpio::PullDown>,
+                gpio::Pin<gpio::bank0::Gpio1, gpio::FunctionUart, gpio::PullDown>,
+            ),
+        >,
+    ) -> Self {
+        uart_writer.disable_tx_interrupt();
+        UartSender { uart_writer }
+    }
+
+    fn get_next_sequence() -> Sequence {
+        static mut SEQUENCE: Sequence = 0;
+        unsafe {
+            SEQUENCE = SEQUENCE.wrapping_add(1);
+            SEQUENCE
+        }
+    }
+
+    fn send(&mut self, packet: &Packet) {
+        let start_time_serialize = Mono::now();
+        let packet = postcard::to_allocvec_cobs(packet).unwrap();
+        let end_time_serialize = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTSenderSendSerialize,
+            start_time_serialize,
+            end_time_serialize,
+        );
+
+        let start_time_transform = Mono::now();
+        let mut buffer = Vec::with_capacity(packet.len() + 1);
+        buffer.push(packet.len() as u8);
+        debug::log_string(
+            debug::LogStringTag::PacketLength,
+            format!("{} bytes", packet.len()),
+        );
+        buffer.extend_from_slice(&packet);
+        let end_time_transform = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTSenderSendTransform,
+            start_time_transform,
+            end_time_transform,
+        );
+
+        let start_time_write = Mono::now();
+        self.uart_writer.write_all(&buffer).unwrap();
+        let end_time_write = Mono::now();
+        debug::log_duration(
+            debug::LogDurationTag::UARTSenderSendWrite,
+            start_time_write,
+            end_time_write,
+        );
+    }
+
+    fn send_response(
+        &mut self,
+        sequence: Sequence,
+        service_id: ServiceId,
+        method_id: MethodId,
+        payload: &[u8],
+    ) {
+        self.send(&Packet {
+            kind: Kind::Response,
+            sequence,
+            service_id,
+            method_id,
+            payload,
+        })
+    }
+}
+
+impl TransportSender for UartSender {
+    fn send_request(
+        &mut self,
+        service_id: ServiceId,
+        method_id: MethodId,
+        payload: &[u8],
+    ) -> Sequence {
+        let sequence = Self::get_next_sequence();
+        self.send(&Packet {
+            kind: Kind::Request,
+            sequence,
+            service_id,
+            method_id,
+            payload,
+        });
+        sequence
+    }
+
+    fn get_payload(
+        &mut self,
+        sequence: Sequence,
+    ) -> Result<(ServiceId, MethodId, &[u8], impl FnMut(&[u8])), super::Error> {
+        let packet = match cortex_m::interrupt::free(|cs| {
+            PACKET_BUFFER.borrow(cs).borrow()[sequence as usize]
+        }) {
+            Some(packet) => {
+                // TODO: dropping here allows the freeing of heap early, but this somehow breaks packet.payload
+                // defmt::warn!(
+                //     "dropping on listen: size={}B",
+                //     mem::size_of_val(packet.payload)
+                // );
+                // drop(unsafe { Box::from_raw(packet.payload as *const [u8] as *mut [u8]) });
+                packet
+            }
+            None => {
+                defmt::error!("packet not found in buffer: seq={}", sequence);
+                return Result::Err(super::Error::MissingPacketBuffer);
+            }
+        };
+
+        Result::Ok((
+            packet.service_id,
+            packet.method_id,
+            packet.payload,
+            move |res: &[u8]| {
+                self.send_response(sequence, packet.service_id, packet.method_id, res)
+            },
+        ))
+    }
+
+    async fn receive_response_poll(&mut self, seq: Sequence) -> Vec<u8> {
+        let stored_payload = loop {
+            if let Some(response) = cortex_m::interrupt::free(|cs| {
+                PACKET_BUFFER.borrow(cs).borrow_mut()[seq as usize].take()
+            }) {
+                break response.payload;
+            }
+            Mono::delay(50.micros()).await;
+        };
+
+        let payload = stored_payload.to_owned();
+        drop(unsafe { Box::from_raw(stored_payload as *const [u8] as *mut [u8]) });
+        payload
+    }
+}
+
+impl RemoteInvoker for UartSender {
+    async fn invoke<'b, Q, R>(
+        &mut self,
+        service_id: ServiceId,
+        method_id: MethodId,
+        request: Q,
+    ) -> R
+    where
+        Q: Serialize,
+        R: Deserialize<'b>,
+    {
+        let mut request_buffer = [0u8; UART_FRAME_BUFFER_SIZE_BYTES];
+        let request_payload = postcard::to_slice(&request, &mut request_buffer).unwrap();
+
+        let seq = self.send_request(service_id, method_id, request_payload);
+
+        let response_buffer = self.receive_response_poll(seq).await.leak();
+        let response_payload = postcard::from_bytes(response_buffer).unwrap();
+        drop(unsafe { Box::from_raw(response_buffer as *const [u8] as *mut [u8]) });
+
+        response_payload
+    }
+}

--- a/src/rotary.rs
+++ b/src/rotary.rs
@@ -39,8 +39,8 @@ pub enum Direction {
 }
 
 pub struct RotaryEncoder {
-    pin_a: Box<dyn InputPin<Error = gpio::Error>>,
-    pin_b: Box<dyn InputPin<Error = gpio::Error>>,
+    pin_a: Box<dyn InputPin<Error = gpio::Error> + Sync + Send>,
+    pin_b: Box<dyn InputPin<Error = gpio::Error> + Sync + Send>,
 
     mode: Mode,
     phase_history: u16,
@@ -49,8 +49,8 @@ pub struct RotaryEncoder {
 
 impl RotaryEncoder {
     pub fn new(
-        pin_a: Box<dyn InputPin<Error = gpio::Error>>,
-        pin_b: Box<dyn InputPin<Error = gpio::Error>>,
+        pin_a: Box<dyn InputPin<Error = gpio::Error> + Sync + Send>,
+        pin_b: Box<dyn InputPin<Error = gpio::Error> + Sync + Send>,
         mut pin_c: Box<dyn OutputPin<Error = gpio::Error>>,
         mode: Mode,
     ) -> Self {

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,0 +1,66 @@
+use alloc::boxed::Box;
+use defmt::Format;
+use embedded_hal::digital::InputPin;
+use hal::gpio;
+
+#[derive(Clone, Copy, Debug, Format, PartialEq)]
+pub enum Side {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Format, PartialEq)]
+pub enum Mode {
+    Master,
+    Slave,
+}
+
+pub struct SideDetector {
+    pin: Box<dyn InputPin<Error = gpio::Error>>,
+}
+
+impl SideDetector {
+    pub fn new(pin: Box<dyn InputPin<Error = gpio::Error>>) -> Self {
+        SideDetector { pin }
+    }
+
+    pub fn detect(&mut self) -> Side {
+        let side = if self.pin.is_high().unwrap() {
+            Side::Left
+        } else {
+            Side::Right
+        };
+        set_self_side(side);
+        side
+    }
+}
+
+static mut SELF_SIDE: Option<Side> = None;
+
+fn set_self_side(side: Side) {
+    unsafe {
+        if SELF_SIDE.is_some() {
+            panic!("self side already set")
+        }
+        SELF_SIDE = Some(side);
+    };
+}
+
+pub fn get_self_side() -> Side {
+    unsafe { SELF_SIDE.expect("self side not set") }
+}
+
+static mut SELF_MODE: Option<Mode> = None;
+
+pub fn set_self_mode(mode: Mode) {
+    unsafe {
+        if SELF_MODE.is_some() {
+            panic!("self mode already set")
+        }
+        SELF_MODE = Some(mode);
+    };
+}
+
+pub fn get_self_mode() -> Mode {
+    unsafe { SELF_MODE.expect("self mode not set") }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,42 +6,43 @@ use rtic_monotonics::rp2040::prelude::*;
 
 use crate::kb::Mono;
 
-pub async fn halt_blink<P: OutputPin + ?Sized>(led: &mut P, us: u32) -> Result<(), P::Error> {
-    match led.set_high() {
+pub async fn blink<P: OutputPin>(
+    pin: &mut P,
+    duty: u8,
+    delay: <Mono as Monotonic>::Duration,
+) -> Result<(), P::Error> {
+    match pin.set_high() {
         Ok(_) => (),
         Err(e) => return Err(e),
     };
-    halt((us / 2) as u64).await;
-    match led.set_low() {
+    Mono::delay((delay.to_nanos() * duty as u64 / u8::MAX as u64).nanos()).await;
+    match pin.set_low() {
         Ok(_) => (),
         Err(e) => return Err(e),
     };
-    halt((us / 2) as u64).await;
+    Mono::delay((delay.to_nanos() * (u8::MAX - duty) as u64 / u8::MAX as u64).nanos()).await;
     Ok(())
 }
 
-pub async fn halt(us: u64) {
-    Mono::delay(us.micros()).await;
-}
-
 pub async fn lerp(
-    pin: &mut Box<dyn SetDutyCycle<Error = gpio::Error>>,
+    pin: &mut Box<dyn SetDutyCycle<Error = gpio::Error> + Sync + Send>,
     from: u16,
     to: u16,
     step: u16,
-    delay_ms: u64,
+    delay: <Mono as Monotonic>::Duration,
 ) {
     let diff = if from < to {
         (to - from) / step
     } else {
         (from - to) / step
     };
+    let step_delay = (delay.to_nanos() / step as u64).nanos();
 
     for d in (0..step)
         .map(|x| x * diff)
         .map(|x| if from < to { from + x } else { from - x })
     {
-        Mono::delay(delay_ms.millis()).await;
         pin.set_duty_cycle(d).unwrap();
+        Mono::delay(step_delay).await;
     }
 }


### PR DESCRIPTION
This PR adds support for split keyboards. For transport, only a basic implementation of UART is implemented.

Configuration for Quadax Rift is also added.

Changes summary:

* Add split scanner (based on BasicVerticalSwitchMatrix)
* Add remote server executor and client invoker
  * Simple flow control implemented
  * No retries or circuit breaker, thus not reliable with higher baud rates
  * Memory allocator increased to 16 KB (from 2 KB)
* Add UART remote transport
* Add split side and mode detection
  * Side detection uses a dedicated pull-down pin
  * Mode detection is based on USB host detection, not VBUS as femto does not have a VBUS detection pin
* Breakdown initialization to two steps
  * Required to detect host for split mode detection
  * Moved some peripherals away from RTIC's local resources to parameter passed to spawned tasks
* Refactor keyboard configuration module
* Add debugging module
* Add run script for both probe and U2F runners for RP2040
* Add keyboard configuration for Quadax Rift

Known issues:

* RGB matrix and rotary encoder does not have remote invocation implemented yet
* High client latency due to high packet serialization overhead
  * Scan result serialization implementation is naive and not performant
  * Achieving 1 kHz polling rate (1 ms main loop period) is difficult with the current configuration
    * At 115200 Baud rate, input scan latency is about 7 ms
    * At 230400 Baud rate, input scan latency is about 4.2 ms, but transmission is sometimes not reliable