### PR TITLE
Compact key matrix scan result serialization

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,4 @@
 use defmt::Format;
-use serde::{Deserialize, Serialize};
 use usbd_human_interface_device::page::Keyboard;
 
 #[allow(dead_code)]
@@ -221,7 +220,7 @@ pub enum Control {
 
 pub trait LayerIndex: Copy + Default + PartialEq + PartialOrd + Format + Into<usize> {}
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Format, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Format, PartialEq)]
 pub enum Edge {
     #[default]
     None,


### PR DESCRIPTION
Implement a more compact key matrix scan result serialization. This bit packing assumes that `Bit` can be represented as 3 bits, thus allowing 3 bytes per 8 `Bit`s.

The changes introduced here reduces the packet size from 88 bytes to 26 bytes (70.5% reduction) on Quadax Rift (35 keys on each side).
