### PR TITLE
Add basic OLED display peripheral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +84,12 @@ dependencies = [
  "tap",
  "wyz",
 ]
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "bytemuck"
@@ -199,6 +211,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "display-interface"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7517c040926d7b02b111884aa089177db80878533127f7c1b480d852c5fb4112"
+
+[[package]]
+name = "display-interface-i2c"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4895cd4e54e5536ef370d7f1eec787aad8275dd8ad15815aebfa71dd847b4ebf"
+dependencies = [
+ "display-interface",
+ "embedded-hal 0.2.7",
+]
+
+[[package]]
+name = "display-interface-spi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489378ad054862146fbd1f09f51d585ccbe4bd1e2feadcda2a13ac33f840e1a5"
+dependencies = [
+ "byte-slice-cast",
+ "display-interface",
+ "embedded-hal 0.2.7",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +260,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
+dependencies = [
+ "az",
+ "byteorder",
 ]
 
 [[package]]
@@ -481,6 +530,7 @@ dependencies = [
  "rtic-sync",
  "serde",
  "smart-leds",
+ "ssd1306",
  "usb-device",
  "usbd-human-interface-device",
  "ws2812-pio",
@@ -942,6 +992,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "ssd1306"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37918f6137f2b58427181c3e10a731bef1061a9756b13ffbade64f21892acc6"
+dependencies = [
+ "display-interface",
+ "display-interface-i2c",
+ "display-interface-spi",
+ "embedded-graphics-core",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ usb-device = "0.3.2"
 usbd-human-interface-device = "0.5.0"
 smart-leds = "0.3.0"
 ws2812-pio = "0.8.0"
+ssd1306 = "0.8.4"
 
 serde = { version = "1.0.204", default-features = false, features = ["derive"] }
 postcard = { version = "1.0.8", features = ["alloc"] }

--- a/src/keyboard/default/mod.rs
+++ b/src/keyboard/default/mod.rs
@@ -24,6 +24,8 @@ const ENABLE_RGB_MATRIX: bool = true;
 pub struct Keyboard {}
 
 impl Configurator for Keyboard {
+    const NAME: &str = "default";
+
     const KEY_MATRIX_ROW_COUNT: usize = 2;
     const KEY_MATRIX_COL_COUNT: usize = 2;
 
@@ -34,9 +36,11 @@ impl Configurator for Keyboard {
         mut slices: pwm::Slices,
         mut pio0: pio::PIO<pac::PIO0>,
         sm0: pio::UninitStateMachine<(pac::PIO0, pio::SM0)>,
+        _i2c1: pac::I2C1,
         _uart0: pac::UART0,
         _resets: &mut pac::RESETS,
         clock_freq: HertzU32,
+        _system_clock: &hal::clocks::SystemClock,
     ) -> (
         Configuration,
         Option<(Arbiter<Rc<RefCell<UartSender>>>, UartReceiver)>,
@@ -94,6 +98,7 @@ impl Configurator for Keyboard {
                 rotary_encoder,
                 heartbeat_led,
                 rgb_matrix,
+                oled_display: None,
             },
             None,
         )

--- a/src/keyboard/kb_dev/mod.rs
+++ b/src/keyboard/kb_dev/mod.rs
@@ -24,6 +24,8 @@ const ENABLE_RGB_MATRIX: bool = true;
 pub struct Keyboard {}
 
 impl Configurator for Keyboard {
+    const NAME: &str = "kb_dev";
+
     const KEY_MATRIX_ROW_COUNT: usize = 5;
     const KEY_MATRIX_COL_COUNT: usize = 15;
 
@@ -34,9 +36,11 @@ impl Configurator for Keyboard {
         mut slices: pwm::Slices,
         mut pio0: pio::PIO<pac::PIO0>,
         sm0: pio::UninitStateMachine<(pac::PIO0, pio::SM0)>,
+        _i2c1: pac::I2C1,
         _uart0: pac::UART0,
         _resets: &mut pac::RESETS,
         clock_freq: HertzU32,
+        _system_clock: &hal::clocks::SystemClock,
     ) -> (
         Configuration,
         Option<(Arbiter<Rc<RefCell<UartSender>>>, UartReceiver)>,
@@ -110,6 +114,7 @@ impl Configurator for Keyboard {
                 rotary_encoder,
                 heartbeat_led,
                 rgb_matrix,
+                oled_display: None,
             },
             None,
         )

--- a/src/oled.rs
+++ b/src/oled.rs
@@ -1,0 +1,37 @@
+use ssd1306::{prelude::*, Ssd1306};
+
+pub struct OLEDDisplay<DI>
+where
+    DI: WriteOnlyDataCommand,
+{
+    // TODO: support arbitrary modes
+    display: Ssd1306<DI, ssd1306::size::DisplaySize128x32, ssd1306::mode::TerminalMode>,
+}
+
+impl<DI> OLEDDisplay<DI>
+where
+    DI: WriteOnlyDataCommand,
+{
+    pub fn new(mut display: Ssd1306<DI, DisplaySize128x32, ssd1306::mode::BasicMode>) -> Self {
+        display.init().unwrap();
+
+        let mut oled_display = OLEDDisplay {
+            display: display.into_terminal_mode(),
+        };
+        oled_display.clear();
+        oled_display
+    }
+
+    pub fn clear(&mut self) {
+        self.display.clear().unwrap();
+    }
+}
+
+impl<DI> core::fmt::Write for OLEDDisplay<DI>
+where
+    DI: WriteOnlyDataCommand,
+{
+    fn write_str(&mut self, s: &str) -> Result<(), core::fmt::Error> {
+        self.display.write_str(s)
+    }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::fmt::Display;
 use defmt::Format;
 use embedded_hal::digital::InputPin;
 use hal::gpio;
@@ -13,6 +14,15 @@ pub enum Side {
 pub enum Mode {
     Master,
     Slave,
+}
+
+impl Display for Mode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Mode::Master => write!(f, "Master"),
+            Mode::Slave => write!(f, "Slave"),
+        }
+    }
 }
 
 pub struct SideDetector {


### PR DESCRIPTION
This PR adds a basic implementation for a SSD1306 OLED display. Keyboard names must also now be defined for each configuration.

Currently, only text mode is supported.
