### PR TITLE
Add basic status LED peripheral

### DIFF
--- a/src/keyboard/default/mod.rs
+++ b/src/keyboard/default/mod.rs
@@ -99,6 +99,7 @@ impl Configurator for Keyboard {
                 heartbeat_led,
                 rgb_matrix,
                 oled_display: None,
+                status_led: None,
             },
             None,
         )

--- a/src/keyboard/kb_dev/mod.rs
+++ b/src/keyboard/kb_dev/mod.rs
@@ -115,6 +115,7 @@ impl Configurator for Keyboard {
                 heartbeat_led,
                 rgb_matrix,
                 oled_display: None,
+                status_led: None,
             },
             None,
         )

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     processor::{events::rgb::RGBMatrix, mapper::InputMap},
     remote::transport::uart::{UartReceiver, UartSender},
     rotary::RotaryEncoder,
+    status::StatusLED,
 };
 
 pub use selected_keyboard::Keyboard;
@@ -74,6 +75,7 @@ pub struct Configuration {
             >,
         >,
     >,
+    pub status_led: Option<StatusLED>,
 }
 
 impl Configuration {

--- a/src/keyboard/quadax_rift/mod.rs
+++ b/src/keyboard/quadax_rift/mod.rs
@@ -1,8 +1,7 @@
 pub mod layout;
 
-use core::cell::RefCell;
-
 use alloc::{boxed::Box, rc::Rc};
+use core::cell::RefCell;
 use hal::{
     fugit::{HertzU32, RateExtU32},
     gpio, pac, pio, pwm, uart,
@@ -20,6 +19,7 @@ use crate::{
     remote::transport::uart::{UartReceiver, UartSender},
     rotary::{Mode, RotaryEncoder},
     split::{self, SideDetector},
+    status::StatusLED,
 };
 
 const ENABLE_HEARTBEAT_LED: bool = true;
@@ -27,6 +27,7 @@ const ENABLE_KEY_MATRIX: bool = true;
 const ENABLE_ROTARY_ENCODER: bool = true;
 const ENABLE_RGB_MATRIX: bool = true;
 const ENABLE_OLED_SCREEN: bool = true;
+const ENABLE_STATUS_LED: bool = true;
 
 pub struct Keyboard {}
 
@@ -125,6 +126,15 @@ impl Configurator for Keyboard {
             None
         };
 
+        let status_led = if ENABLE_STATUS_LED {
+            Some(StatusLED::new(
+                Box::new(pins.gpio24.into_push_pull_output()),
+                Box::new(pins.gpio25.into_push_pull_output()),
+            ))
+        } else {
+            None
+        };
+
         let mut uart_peripheral = uart::UartPeripheral::new(
             uart0,
             (pins.gpio0.into_function(), pins.gpio1.into_function()),
@@ -154,6 +164,7 @@ impl Configurator for Keyboard {
                 heartbeat_led,
                 rgb_matrix,
                 oled_display,
+                status_led,
             },
             Some((uart_sender, uart_receiver)),
         )

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,73 @@
+use alloc::boxed::Box;
+use embedded_hal::digital::OutputPin;
+use hal::gpio;
+use rtic_monotonics::rp2040::prelude::*;
+
+use crate::kb::Mono;
+
+const ACTIVITY_UPDATE_PERIOD_TICK: u64 = 5_000;
+const ACTIVITY_DELAY_PERIOD_TICK: u64 = 300_000;
+
+pub struct StatusLED {
+    link_led: Box<dyn OutputPin<Error = gpio::Error> + Sync + Send>,
+    activity_led: Box<dyn OutputPin<Error = gpio::Error> + Sync + Send>,
+    activity_led_state: gpio::PinState,
+    activity_last_update_tick: u64,
+    activity_last_active_tick: u64,
+    counter: u16,
+}
+
+impl StatusLED {
+    pub fn new(
+        mut link_led: Box<dyn OutputPin<Error = gpio::Error> + Send + Sync>,
+        mut activity_led: Box<dyn OutputPin<Error = gpio::Error> + Send + Sync>,
+    ) -> Self {
+        link_led.set_low().unwrap();
+        activity_led.set_low().unwrap();
+
+        StatusLED {
+            link_led,
+            activity_led,
+            activity_led_state: gpio::PinState::High,
+            activity_last_update_tick: 0,
+            activity_last_active_tick: 0,
+            counter: 0,
+        }
+    }
+
+    pub fn set_link(&mut self, enable: bool) {
+        self.link_led
+            .set_state(if enable {
+                gpio::PinState::High
+            } else {
+                gpio::PinState::Low
+            })
+            .unwrap();
+    }
+
+    pub fn update_activity(&mut self, active: bool) {
+        let now_tick = Mono::now().ticks();
+        if now_tick - self.activity_last_update_tick < ACTIVITY_UPDATE_PERIOD_TICK {
+            return;
+        }
+        self.activity_last_update_tick = now_tick;
+        self.counter = self.counter.wrapping_add(1);
+        if active {
+            self.activity_last_active_tick = now_tick;
+        }
+
+        self.activity_led_state =
+            if active || now_tick - self.activity_last_active_tick < ACTIVITY_DELAY_PERIOD_TICK {
+                if self.counter % 12 < 6 {
+                    gpio::PinState::Low
+                } else {
+                    gpio::PinState::High
+                }
+            } else {
+                gpio::PinState::High
+            };
+        self.activity_led
+            .set_state(self.activity_led_state)
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This PR adds a basic status LED peripheral to represent remote link and activity. This peripheral is particularly used for Quadax Rift's RJ45 status LEDs.

Implementation is very basic and only works on the master side.
