### PR TITLE
Support modified keys

### DIFF
--- a/src/keyboard/default/layout/default.rs
+++ b/src/keyboard/default/layout/default.rs
@@ -1,6 +1,5 @@
-#![allow(dead_code)]
 use defmt::Format;
-use enum_map::enum_map;
+use enum_map::{enum_map, Enum};
 
 use crate::{
     key::{
@@ -12,9 +11,7 @@ use crate::{
     rotary::Direction,
 };
 
-pub const LAYER_COUNT: usize = 2;
-
-#[derive(Clone, Copy, Default, Format, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Enum, Format, PartialEq, PartialOrd)]
 pub enum Layer {
     #[default]
     Base,
@@ -23,36 +20,35 @@ pub enum Layer {
 
 impl LayerIndex for Layer {}
 
-impl From<Layer> for usize {
-    fn from(value: Layer) -> usize {
-        value as usize
-    }
-}
-
-#[rustfmt::skip]
-pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
+pub fn get_input_map() -> InputMap<
+    { <super::super::Keyboard as Configurator>::LAYER_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+    <super::super::Keyboard as Configurator>::Layer,
+> {
+    #[rustfmt::skip]
     InputMap::new(
-        [
-            [
+        enum_map! {
+            Layer::Base => [
                 [K(Key::A),                    K(Key::B)],
                 [___________,                  LM(Layer::Function1)],
             ],
-            [
+            Layer::Function1 => [
                 [K(Key::C),                    K(Key::D)],
                 [C(Control::RGBAnimationNext), ___________],
             ],
-        ],
-        [
-            enum_map! {
+        },
+        enum_map! {
+            Layer::Base => enum_map! {
                 Direction::Clockwise => C(Control::RGBBrightnessUp),
                 Direction::CounterClockwise => C(Control::RGBBrightnessDown),
                 _ => ___________,
             },
-            enum_map! {
+            Layer::Function1 => enum_map! {
                 Direction::Clockwise => C(Control::RGBSpeedUp),
                 Direction::CounterClockwise => C(Control::RGBSpeedDown),
                 _ => ___________,
             },
-        ],
+        },
     )
 }

--- a/src/keyboard/default/layout/mod.rs
+++ b/src/keyboard/default/layout/mod.rs
@@ -3,8 +3,6 @@ mod default;
 #[cfg(layout = "default")]
 use default as selected_layout;
 
-pub use selected_layout::LAYER_COUNT;
-
 pub use selected_layout::Layer;
 
 pub use selected_layout::get_input_map;

--- a/src/keyboard/kb_dev/layout/default.rs
+++ b/src/keyboard/kb_dev/layout/default.rs
@@ -1,6 +1,5 @@
-#![allow(dead_code)]
 use defmt::Format;
-use enum_map::enum_map;
+use enum_map::{enum_map, Enum};
 
 use crate::{
     key::{
@@ -12,9 +11,7 @@ use crate::{
     rotary::Direction,
 };
 
-pub const LAYER_COUNT: usize = 3;
-
-#[derive(Clone, Copy, Default, Format, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Enum, Format, PartialEq, PartialOrd)]
 pub enum Layer {
     #[default]
     Base,
@@ -24,54 +21,53 @@ pub enum Layer {
 
 impl LayerIndex for Layer {}
 
-impl From<Layer> for usize {
-    fn from(value: Layer) -> usize {
-        value as usize
-    }
-}
-
-#[rustfmt::skip]
-pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
+pub fn get_input_map() -> InputMap<
+    { <super::super::Keyboard as Configurator>::LAYER_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+    <super::super::Keyboard as Configurator>::Layer,
+> {
+    #[rustfmt::skip]
     InputMap::new(
-        [
-            [
+        enum_map! {
+            Layer::Base => [
                 [K(Key::Escape), K(Key::Keyboard1), K(Key::Keyboard2), K(Key::Keyboard3), K(Key::Keyboard4), K(Key::Keyboard5), K(Key::Keyboard6), K(Key::Keyboard7), K(Key::Keyboard8), K(Key::Keyboard9), K(Key::Keyboard0), K(Key::Minus), K(Key::Equal), K(Key::DeleteBackspace), K(Key::DeleteForward)],
                 [K(Key::Tab), K(Key::Q), K(Key::W), K(Key::E), K(Key::R), K(Key::T), K(Key::Y), K(Key::U), K(Key::I), K(Key::O), K(Key::P), K(Key::LeftBrace), K(Key::RightBrace), K(Key::Backslash), K(Key::Home)],
                 [K(Key::CapsLock), K(Key::A), K(Key::S), K(Key::D), K(Key::F), K(Key::G), K(Key::H), K(Key::J), K(Key::K), K(Key::L), K(Key::Semicolon), K(Key::Apostrophe), ___________, K(Key::ReturnEnter), K(Key::PageUp)],
                 [K(Key::LeftShift), K(Key::Z), K(Key::X), K(Key::C), K(Key::V), K(Key::B), K(Key::N), K(Key::M), K(Key::Comma), K(Key::Dot), K(Key::ForwardSlash), ___________, K(Key::RightShift), K(Key::UpArrow), K(Key::PageDown)],
                 [K(Key::LeftControl), K(Key::LeftAlt), K(Key::LeftGUI), ___________, ___________, ___________, K(Key::Space), ___________, ___________, ___________, LM(Layer::Function1), K(Key::RightAlt), K(Key::LeftArrow), K(Key::DownArrow), K(Key::RightArrow)],
             ],
-            [
+            Layer::Function1 => [
                 [K(Key::Grave), K(Key::F1), K(Key::F2), K(Key::F3), K(Key::F4), K(Key::F5), K(Key::F6), K(Key::F7), K(Key::F8), K(Key::F9), K(Key::F10), K(Key::F11), K(Key::F12), ___________, ___________],
                 [___________, C(Control::RGBAnimationNext), C(Control::RGBSpeedUp), C(Control::RGBBrightnessUp), ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [___________, C(Control::RGBAnimationPrevious), C(Control::RGBSpeedDown), C(Control::RGBBrightnessDown), ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [K(Key::LeftShift), ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, K(Key::RightShift), ___________, ___________],
                 [K(Key::LeftControl), K(Key::LeftAlt), K(Key::LeftGUI), ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, LM(Layer::Function2), ___________, ___________, ___________],
             ],
-            [
+            Layer::Function2 => [
                 [___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
                 [___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________, ___________],
             ],
-        ],
-        [
-            enum_map! {
+        },
+        enum_map! {
+            Layer::Base => enum_map! {
                 Direction::Clockwise => K(Key::VolumeUp),
                 Direction::CounterClockwise => K(Key::VolumeDown),
                 _ => ___________,
             },
-            enum_map! {
+            Layer::Function1 => enum_map! {
                 Direction::Clockwise => C(Control::RGBBrightnessUp),
                 Direction::CounterClockwise => C(Control::RGBBrightnessDown),
                 _ => ___________,
             },
-            enum_map! {
+            Layer::Function2 => enum_map! {
                 Direction::Clockwise => C(Control::RGBSpeedUp),
                 Direction::CounterClockwise => C(Control::RGBSpeedDown),
                 _ => ___________,
             },
-        ],
+        },
     )
 }

--- a/src/keyboard/kb_dev/layout/mod.rs
+++ b/src/keyboard/kb_dev/layout/mod.rs
@@ -3,8 +3,6 @@ mod default;
 #[cfg(layout = "default")]
 use default as selected_layout;
 
-pub use selected_layout::LAYER_COUNT;
-
 pub use selected_layout::Layer;
 
 pub use selected_layout::get_input_map;

--- a/src/keyboard/kb_dev/mod.rs
+++ b/src/keyboard/kb_dev/mod.rs
@@ -24,7 +24,7 @@ const ENABLE_RGB_MATRIX: bool = true;
 pub struct Keyboard {}
 
 impl Configurator for Keyboard {
-    const NAME: &str = "kb_dev";
+    const NAME: &str = "kb-dev";
 
     const KEY_MATRIX_ROW_COUNT: usize = 5;
     const KEY_MATRIX_COL_COUNT: usize = 15;

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -1,6 +1,5 @@
-use core::cell::RefCell;
-
 use alloc::rc::Rc;
+use core::{cell::RefCell, mem};
 use hal::{fugit::HertzU32, gpio, pac, pio, pwm};
 use rtic_sync::arbiter::Arbiter;
 use ssd1306::prelude::I2CInterface;
@@ -87,8 +86,8 @@ impl Configuration {
 pub trait Configurator {
     const NAME: &str;
 
-    const LAYER_COUNT: usize = selected_keyboard::layout::LAYER_COUNT;
     type Layer: LayerIndex = selected_keyboard::layout::Layer;
+    const LAYER_COUNT: usize = mem::variant_count::<Self::Layer>();
 
     const KEY_MATRIX_ROW_COUNT: usize;
     const KEY_MATRIX_COL_COUNT: usize;
@@ -111,9 +110,9 @@ pub trait Configurator {
     );
 
     fn get_input_map() -> InputMap<
-        { selected_keyboard::layout::LAYER_COUNT },
-        { selected_keyboard::Keyboard::KEY_MATRIX_ROW_COUNT },
-        { selected_keyboard::Keyboard::KEY_MATRIX_COL_COUNT },
+        { <selected_keyboard::Keyboard as Configurator>::LAYER_COUNT },
+        { <selected_keyboard::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+        { <selected_keyboard::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
         selected_keyboard::layout::Layer,
     > {
         selected_keyboard::layout::get_input_map()

--- a/src/keyboard/quadax_rift/layout/default.rs
+++ b/src/keyboard/quadax_rift/layout/default.rs
@@ -12,8 +12,6 @@ use crate::{
     rotary::Direction,
 };
 
-pub const LAYER_COUNT: usize = 3;
-
 #[derive(Clone, Copy, Default, Format, PartialEq, PartialOrd)]
 pub enum Layer {
     #[default]

--- a/src/keyboard/quadax_rift/layout/default.rs
+++ b/src/keyboard/quadax_rift/layout/default.rs
@@ -1,75 +1,99 @@
-#![allow(dead_code)]
 use defmt::Format;
-use enum_map::enum_map;
+use enum_map::{enum_map, Enum};
 
 use crate::{
     key::{
-        Action::{Control as C, Key as K, LayerModifier as LM, Pass as ___________},
-        Control, Key, LayerIndex,
+        Action::{
+            Control as C, Key as K, LayerModifier as LM, ModifiedKey as MK, Pass as ___________,
+        },
+        Control, Key, LayerIndex, ModifiedKey, Modifier,
     },
     keyboard::Configurator,
     processor::mapper::InputMap,
     rotary::Direction,
 };
 
-#[derive(Clone, Copy, Default, Format, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Enum, Format, PartialEq, PartialOrd)]
 pub enum Layer {
     #[default]
     Base,
-    Down,
-    Up,
+    Symbol,
+    Number,
+    Navigation,
+    System,
 }
 
 impl LayerIndex for Layer {}
 
-impl From<Layer> for usize {
-    fn from(value: Layer) -> usize {
-        value as usize
-    }
-}
-
-#[rustfmt::skip]
-pub fn get_input_map() -> InputMap<{ <super::super::Keyboard as Configurator>::LAYER_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT }, { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT }, <super::super::Keyboard as Configurator>::Layer> {
+pub fn get_input_map() -> InputMap<
+    { <super::super::Keyboard as Configurator>::LAYER_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_ROW_COUNT },
+    { <super::super::Keyboard as Configurator>::KEY_MATRIX_COL_COUNT },
+    <super::super::Keyboard as Configurator>::Layer,
+> {
+    #[rustfmt::skip]
     InputMap::new(
-        [
-            [
+        enum_map! {
+            Layer::Base => [
                 [K(Key::Escape),        K(Key::Keyboard1),     K(Key::Keyboard2),     K(Key::Keyboard3),     K(Key::Keyboard4),     K(Key::Keyboard5),     ___________,           ___________,           K(Key::Keyboard6),     K(Key::Keyboard7),     K(Key::Keyboard8),     K(Key::Keyboard9),     K(Key::Keyboard0),     K(Key::DeleteBackspace)],
                 [K(Key::Tab),           K(Key::Q),             K(Key::W),             K(Key::E),             K(Key::R),             K(Key::T),             ___________,           ___________,           K(Key::Y),             K(Key::U),             K(Key::I),             K(Key::O),             K(Key::P),             K(Key::DeleteForward)],
-                [K(Key::CapsLock),      K(Key::A),             K(Key::S),             K(Key::D),             K(Key::F),             K(Key::G),             ___________,           ___________,           K(Key::H),             K(Key::J),             K(Key::K),             K(Key::L),             K(Key::Semicolon),     K(Key::ReturnEnter)],
-                [K(Key::LeftShift),     K(Key::Z),             K(Key::X),             K(Key::C),             K(Key::V),             K(Key::B),             ___________,           ___________,           K(Key::N),             K(Key::M),             K(Key::Comma),         K(Key::Dot),           K(Key::ForwardSlash),  K(Key::RightShift)],
-                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       LM(Layer::Down),       K(Key::Space),         ___________,           ___________,           K(Key::Space),         LM(Layer::Up),         K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
+                [K(Key::LeftControl),   K(Key::A),             K(Key::S),             K(Key::D),             K(Key::F),             K(Key::G),             ___________,           ___________,           K(Key::H),             K(Key::J),             K(Key::K),             K(Key::L),             K(Key::Semicolon),     K(Key::ReturnEnter)],
+                [K(Key::LeftShift),     K(Key::Z),             K(Key::X),             K(Key::C),             K(Key::V),             K(Key::B),             LM(Layer::Number),     ___________,           K(Key::N),             K(Key::M),             K(Key::Comma),         K(Key::Dot),           MK(LS!(Key::ForwardSlash)),K(Key::RightShift)],
+                [LM(Layer::System),     K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       LM(Layer::Symbol),     K(Key::Space),         ___________,           ___________,           K(Key::Space),         LM(Layer::Navigation), K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
             ],
-            [
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           C(Control::RGBAnimationNext), C(Control::RGBSpeedUp), C(Control::RGBBrightnessUp),           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           C(Control::RGBAnimationPrevious), C(Control::RGBSpeedDown), C(Control::RGBBrightnessDown),           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+            Layer::Symbol => [
+                [K(Key::Escape),        MK(LS!(Key::Keyboard1)),MK(LS!(Key::Keyboard2)),MK(LS!(Key::Keyboard3)),MK(LS!(Key::Keyboard4)),___________,       ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::DeleteBackspace)],
+                [___________,           MK(LS!(Key::LeftBrace)),K(Key::LeftBrace),     K(Key::Apostrophe),   K(Key::RightBrace),    MK(LS!(Key::RightBrace)),___________,         ___________,           MK(LS!(Key::Comma)),   MK(LS!(Key::Dot)),     ___________,           ___________,           ___________,           ___________],
+                [K(Key::LeftControl),   K(Key::Backslash),     MK(LS!(Key::Keyboard9)),MK(LS!(Key::Apostrophe)),MK(LS!(Key::Keyboard0)),K(Key::ForwardSlash),___________,         ___________,           MK(LS!(Key::Minus)),   MK(LS!(Key::Backslash)),MK(LS!(Key::Keyboard7)),MK(LS!(Key::Keyboard6)),K(Key::Equal),   ___________],
+                [K(Key::LeftShift),     ___________,           MK(LS!(Key::Comma)),    K(Key::Grave),        MK(LS!(Key::Dot)),     ___________,           LM(Layer::Number),     ___________,           MK(LS!(Key::Equal)),   K(Key::Minus),         MK(LS!(Key::Keyboard8)),MK(LS!(Key::Grave)),  MK(LS!(Key::Keyboard5)),K(Key::RightShift)],
+                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       ___________,           K(Key::Space),         ___________,           ___________,           K(Key::Space),         ___________,           K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
             ],
-            [
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::LeftArrow),     K(Key::DownArrow),     K(Key::UpArrow),       K(Key::RightArrow),    ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
-                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________],
+            Layer::Number => [
+                [K(Key::Escape),        ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::DeleteBackspace)],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::Keyboard0),     K(Key::Keyboard1),     K(Key::Keyboard2),     K(Key::Keyboard3),     ___________,           ___________],
+                [K(Key::LeftControl),   ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::Keyboard4),     K(Key::Keyboard5),     K(Key::Keyboard6),     ___________,           ___________],
+                [K(Key::LeftShift),     ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::Keyboard7),     K(Key::Keyboard8),     K(Key::Keyboard9),     ___________,           K(Key::RightShift)],
+                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       ___________,           K(Key::Space),         ___________,           ___________,           K(Key::Space),         ___________,           K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
             ],
-        ],
-        [
-            enum_map! {
+            Layer::Navigation => [
+                [K(Key::Escape),        ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::DeleteBackspace)],
+                [___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::Home),          K(Key::PageDown),      K(Key::PageUp),        K(Key::End),           ___________,           ___________],
+                [K(Key::LeftControl),   ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::LeftArrow),     K(Key::DownArrow),     K(Key::UpArrow),       K(Key::RightArrow),    ___________,           ___________],
+                [K(Key::LeftShift),     ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::RightShift)],
+                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       ___________,           K(Key::Space),         ___________,           ___________,           K(Key::Space),         ___________,           K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
+            ],
+            Layer::System => [
+                [K(Key::Escape),        ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::DeleteBackspace)],
+                [___________,           C(Control::RGBAnimationNext),C(Control::RGBSpeedUp),C(Control::RGBBrightnessUp),___________,___________,           ___________,           ___________,           K(Key::F10),           K(Key::F1),            K(Key::F2),            K(Key::F3),            ___________,           ___________],
+                [K(Key::LeftControl),   C(Control::RGBAnimationPrevious),C(Control::RGBSpeedDown),C(Control::RGBBrightnessDown),___________,___________,   ___________,           ___________,           K(Key::F11),           K(Key::F4),            K(Key::F5),            K(Key::F6),            ___________,           ___________],
+                [K(Key::LeftShift),     ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           ___________,           K(Key::F12),           K(Key::F7),            K(Key::F8),            K(Key::F9),            ___________,           K(Key::RightShift)],
+                [___________,           K(Key::LeftControl),   K(Key::LeftAlt),       K(Key::LeftGUI),       ___________,           K(Key::Space),         ___________,           ___________,           K(Key::Space),         ___________,           K(Key::RightGUI),      K(Key::RightAlt),      K(Key::RightControl),  ___________],
+            ],
+        },
+        enum_map! {
+            Layer::Base => enum_map! {
                 Direction::Clockwise => K(Key::VolumeUp),
                 Direction::CounterClockwise => K(Key::VolumeDown),
                 _ => ___________,
             },
-            enum_map! {
+            Layer::Symbol => enum_map! {
                 Direction::Clockwise => C(Control::RGBBrightnessUp),
                 Direction::CounterClockwise => C(Control::RGBBrightnessDown),
                 _ => ___________,
             },
-            enum_map! {
+            Layer::Number => enum_map! {
+                Direction::Clockwise => C(Control::RGBBrightnessUp),
+                Direction::CounterClockwise => C(Control::RGBBrightnessDown),
+                _ => ___________,
+            },
+            Layer::Navigation => enum_map! {
                 Direction::Clockwise => C(Control::RGBSpeedUp),
                 Direction::CounterClockwise => C(Control::RGBSpeedDown),
                 _ => ___________,
             },
-        ],
+            Layer::System => enum_map! {
+                _ => ___________,
+            },
+        },
     )
 }

--- a/src/keyboard/quadax_rift/layout/mod.rs
+++ b/src/keyboard/quadax_rift/layout/mod.rs
@@ -3,8 +3,6 @@ mod default;
 #[cfg(layout = "default")]
 use default as selected_layout;
 
-pub use selected_layout::LAYER_COUNT;
-
 pub use selected_layout::Layer;
 
 pub use selected_layout::get_input_map;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,13 @@
 #![feature(variant_count)]
 #![allow(incomplete_features)]
 #![allow(refining_impl_trait)]
+#![allow(unused_macros)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::await_holding_refcell_ref)]
 mod debug;
 mod heartbeat;
+#[macro_use]
 mod key;
 mod keyboard;
 mod matrix;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 #![feature(async_closure)]
 #![feature(generic_const_exprs)]
 #![feature(future_join)]
+#![feature(variant_count)]
 #![allow(incomplete_features)]
 #![allow(refining_impl_trait)]
 #![allow(clippy::type_complexity)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 #![feature(generic_const_exprs)]
 #![feature(future_join)]
 #![feature(variant_count)]
+#![feature(stmt_expr_attributes)]
 #![allow(incomplete_features)]
 #![allow(refining_impl_trait)]
 #![allow(unused_macros)]

--- a/src/processor/mapper.rs
+++ b/src/processor/mapper.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use enum_map::EnumMap;
+use enum_map::{EnumArray, EnumMap};
 
 use crate::{
     key::{Action, Edge, LayerIndex},
@@ -18,22 +18,26 @@ pub struct InputMap<
     const LAYER_COUNT: usize,
     const KEY_MATRIX_ROW_COUNT: usize,
     const KEY_MATRIX_COL_COUNT: usize,
-    L: LayerIndex,
+    L: LayerIndex
+        + EnumArray<[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>
+        + EnumArray<EnumMap<Direction, Action<L>>>,
 > {
-    key_matrix: [[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]; LAYER_COUNT],
-    rotary_encoder: [EnumMap<Direction, Action<L>>; LAYER_COUNT],
+    key_matrix: EnumMap<L, [[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>,
+    rotary_encoder: EnumMap<L, EnumMap<Direction, Action<L>>>,
 }
 
 impl<
         const LAYER_COUNT: usize,
         const KEY_MATRIX_ROW_COUNT: usize,
         const KEY_MATRIX_COL_COUNT: usize,
-        L: LayerIndex,
+        L: LayerIndex
+            + EnumArray<[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>
+            + EnumArray<EnumMap<Direction, Action<L>>>,
     > InputMap<LAYER_COUNT, KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT, L>
 {
     pub const fn new(
-        key_matrix: [[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]; LAYER_COUNT],
-        rotary_encoder: [EnumMap<Direction, Action<L>>; LAYER_COUNT],
+        key_matrix: EnumMap<L, [[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>,
+        rotary_encoder: EnumMap<L, EnumMap<Direction, Action<L>>>,
     ) -> Self {
         InputMap {
             key_matrix,
@@ -46,7 +50,9 @@ pub struct Mapper<
     const LAYER_COUNT: usize,
     const KEY_MATRIX_ROW_COUNT: usize,
     const KEY_MATRIX_COL_COUNT: usize,
-    L: LayerIndex,
+    L: LayerIndex
+        + EnumArray<[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>
+        + EnumArray<EnumMap<Direction, Action<L>>>,
 > {
     previous_key_matrix_result: MatrixResult<KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT>,
     mapping: InputMap<LAYER_COUNT, KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT, L>,
@@ -56,7 +62,9 @@ impl<
         const LAYER_COUNT: usize,
         const KEY_MATRIX_ROW_COUNT: usize,
         const KEY_MATRIX_COL_COUNT: usize,
-        L: LayerIndex,
+        L: LayerIndex
+            + EnumArray<[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>
+            + EnumArray<EnumMap<Direction, Action<L>>>,
     > Mapper<LAYER_COUNT, KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT, L>
 {
     pub fn new(
@@ -73,7 +81,9 @@ impl<
         const LAYER_COUNT: usize,
         const KEY_MATRIX_ROW_COUNT: usize,
         const KEY_MATRIX_COL_COUNT: usize,
-        L: LayerIndex,
+        L: LayerIndex
+            + EnumArray<[[Action<L>; KEY_MATRIX_COL_COUNT]; KEY_MATRIX_ROW_COUNT]>
+            + EnumArray<EnumMap<Direction, Action<L>>>,
     > Mapper<LAYER_COUNT, KEY_MATRIX_ROW_COUNT, KEY_MATRIX_COL_COUNT, L>
 {
     pub fn map(
@@ -91,7 +101,7 @@ impl<
             new_layer = false;
             for (i, row) in result.matrix.iter().enumerate() {
                 for (j, bit) in row.iter().enumerate() {
-                    let action = self.mapping.key_matrix[layer.into()][i][j];
+                    let action = self.mapping.key_matrix[layer][i][j];
                     if bit.pressed {
                         if let Action::LayerModifier(l) = action {
                             if layer < l {
@@ -124,7 +134,7 @@ impl<
                 i: 0,
                 j: 0,
                 edge: result.edge,
-                action: self.mapping.rotary_encoder[layer.into()][result.direction],
+                action: self.mapping.rotary_encoder[layer][result.direction],
             });
         }
 


### PR DESCRIPTION
Allows the composition of keys+modifiers (i.e., modified keys) to a single action. Layer count is now deduced from the enum variant count using `core::mem::variant_count()`. Input map is also changed to use enum maps.

Simple macros are added to easily compose modifier combinations for a given key.

This PR also updates the default layout for Quadax Rift.